### PR TITLE
Further Merkle Tree Optimizations

### DIFF
--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -1,0 +1,52 @@
+defmodule Examples.EMerkleTree do
+  require ExUnit.Assertions
+  import ExUnit.Assertions
+  alias Anoma.LocalDomain.MerkleTree
+
+  def add_leaf_to_merkle_tree() do
+    empty_tree = MerkleTree.new()
+
+    empty_tree |> MerkleTree.add_leaf(:crypto.hash(:sha256, "a"))
+  end
+
+  def write_to_merkle_tree() do
+    empty_tree = MerkleTree.new()
+
+    new_tree =
+      empty_tree
+      |> MerkleTree.add(:crypto.hash(:sha256, "a"))
+
+    assert Enum.at(Map.get(new_tree.nodes, 1), 0) ==
+             :crypto.hash(
+               :sha256,
+               :crypto.hash(:sha256, "a") <>
+                 :crypto.hash(:sha256, "EMPTY")
+             )
+
+    new_tree
+  end
+
+  def expand_merkle_tree() do
+    new_tree =
+      write_to_merkle_tree()
+      |> MerkleTree.add(:crypto.hash(:sha256, "b"))
+      |> MerkleTree.add(:crypto.hash(:sha256, "c"))
+
+    new_tree
+  end
+
+  def generate_a_proof() do
+    tree = expand_merkle_tree()
+
+    {frontiers, root} =
+      MerkleTree.generate_proof(tree, :crypto.hash(:sha256, "b"))
+
+    assert root == MerkleTree.root(tree)
+    {frontiers, root}
+  end
+
+  def verify_a_proof() do
+    {frontiers, root} = generate_a_proof()
+    MerkleTree.verify_proof(:crypto.hash(:sha256, "b"), frontiers, root)
+  end
+end

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -155,8 +155,12 @@ defmodule Examples.EMerkleTree do
   def block(number) do
     initial_leaf = :crypto.strong_rand_bytes(32)
 
-    for _i <- 2..number, reduce: [initial_leaf] do
-      [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+    if number == 1 do
+      [initial_leaf]
+    else
+      for _i <- 2..number, reduce: [initial_leaf] do
+        [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+      end
     end
   end
 
@@ -191,8 +195,6 @@ defmodule Examples.EMerkleTree do
         "Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}"
       )
 
-      IO.puts("Block size: #{inspect(block_size)}")
-      IO.puts("Block number: #{inspect(block_number)}")
       IO.puts("Time factor difference: #{inspect(t1 / t2)}")
     else
       IO.puts("Sequential Approach is Faster")
@@ -201,9 +203,18 @@ defmodule Examples.EMerkleTree do
         "Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}"
       )
 
-      IO.puts("Block size: #{inspect(block_size)}")
-      IO.puts("Block number: #{inspect(block_number)}")
       IO.puts("Time factor difference: #{inspect(t2 / t1)}")
     end
+
+    IO.puts("Block size: #{inspect(block_size)}")
+    IO.puts("Block number: #{inspect(block_number)}")
+
+    IO.puts(
+      "Average sequential block processed in: #{inspect(t1 / block_number)}"
+    )
+
+    IO.puts(
+      "Average batch block processed in: #{inspect(t2 / block_number)}"
+    )
   end
 end

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -12,7 +12,7 @@ defmodule Examples.EMerkleTree do
       empty_tree()
       |> MerkleTree.add([:crypto.hash(:sha256, "a")])
 
-    assert Enum.at(Map.get(new_tree.nodes, 1), 0) ==
+    assert Map.get(Map.get(new_tree.nodes, 1), 0) ==
              :crypto.hash(
                :sha256,
                :crypto.hash(:sha256, "a") <>
@@ -65,8 +65,13 @@ defmodule Examples.EMerkleTree do
 
     new_tree = MerkleTree.add(empty_tree(), leaves)
 
+    sorted_leaves = Map.get(new_tree.nodes, 0)
+    |> Map.to_list()
+    |> Enum.sort(fn {ind1, _}, {ind2, _} -> ind1 < ind2 end)
+    |> Enum.map(&(elem(&1, 1)))
+
     # Check that the leaves are as expected
-    assert List.starts_with?(Map.get(new_tree.nodes, 0), leaves)
+    assert List.starts_with?(sorted_leaves, leaves)
 
     # Check that index is as expected
     assert new_tree.next_index == leaves_length

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -139,7 +139,7 @@ defmodule Examples.EMerkleTree do
     tree1 = MerkleTree.new()
     tree2 = MerkleTreeChunk.new()
 
-    for i <- 1..300000, reduce: {tree1, tree2} do
+    for i <- 1..500000, reduce: {tree1, tree2} do
       {tree1, tree2} ->
         leaf = :crypto.hash(:sha256, :erlang.term_to_binary(i))
         upd_tree1 = MerkleTree.add(tree1, [leaf])

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -135,11 +135,11 @@ defmodule Examples.EMerkleTree do
     end
   end
 
-  def merkle_tree_differential() do
+  def merkle_tree_differential(leaves_number) do
     tree1 = MerkleTree.new()
     tree2 = MerkleTreeChunk.new()
 
-    for i <- 1..500000, reduce: {tree1, tree2} do
+    for i <- 1..leaves_number, reduce: {tree1, tree2} do
       {tree1, tree2} ->
         leaf = :crypto.hash(:sha256, :erlang.term_to_binary(i))
         upd_tree1 = MerkleTree.add(tree1, [leaf])
@@ -158,11 +158,10 @@ defmodule Examples.EMerkleTree do
     end
   end
 
-  def merkle_tree_comparisson(block_size, block_number) do
-    tree1 = MerkleTree.new()
-    tree2 = MerkleTreeChunk.new()
+  def merkle_tree_comparisson(initial_commitment_size, block_size, block_number) do
+    {initial_tree1, initial_tree2} = merkle_tree_differential(initial_commitment_size)
 
-   {{t1, _}, {t2, _}} =  for _i <- 1..block_number, reduce: {{0, tree1}, {0, tree2}} do
+   {{t1, _}, {t2, _}} =  for _i <- 1..block_number, reduce: {{0, initial_tree1}, {0, initial_tree2}} do
       {{time1, tree1}, {time2, tree2}} ->
         block = block(block_size)
         {time_tree1, upd_tree1} = :timer.tc(fn -> MerkleTree.add(tree1, block) end)
@@ -173,11 +172,13 @@ defmodule Examples.EMerkleTree do
 
     if t1 > t2 do
       IO.puts("Batch Approach is Faster")
+      IO.puts("Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}")
       IO.puts("Block size: #{inspect(block_size)}")
       IO.puts("Block number: #{inspect(block_number)}")
       IO.puts("Time factor difference: #{inspect(t1 / t2)}")
     else
       IO.puts("Sequential Approach is Faster")
+      IO.puts("Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}")
       IO.puts("Block size: #{inspect(block_size)}")
       IO.puts("Block number: #{inspect(block_number)}")
       IO.puts("Time factor difference: #{inspect(t2 / t1)}")

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -3,18 +3,14 @@ defmodule Examples.EMerkleTree do
   import ExUnit.Assertions
   alias Anoma.LocalDomain.MerkleTree
 
-  def add_leaf_to_merkle_tree() do
-    empty_tree = MerkleTree.new()
-
-    empty_tree |> MerkleTree.add_leaf(:crypto.hash(:sha256, "a"))
+  def empty_tree() do
+    MerkleTree.new()
   end
 
   def write_to_merkle_tree() do
-    empty_tree = MerkleTree.new()
-
     new_tree =
-      empty_tree
-      |> MerkleTree.add(:crypto.hash(:sha256, "a"))
+      empty_tree()
+      |> MerkleTree.add([:crypto.hash(:sha256, "a")])
 
     assert Enum.at(Map.get(new_tree.nodes, 1), 0) ==
              :crypto.hash(
@@ -23,14 +19,20 @@ defmodule Examples.EMerkleTree do
                  :crypto.hash(:sha256, "EMPTY")
              )
 
+    assert new_tree.capacity == 2
+
     new_tree
   end
 
   def expand_merkle_tree() do
     new_tree =
       write_to_merkle_tree()
-      |> MerkleTree.add(:crypto.hash(:sha256, "b"))
-      |> MerkleTree.add(:crypto.hash(:sha256, "c"))
+      |> MerkleTree.add([
+        :crypto.hash(:sha256, "b"),
+        :crypto.hash(:sha256, "c")
+      ])
+
+    assert new_tree.capacity == 4
 
     new_tree
   end
@@ -48,5 +50,32 @@ defmodule Examples.EMerkleTree do
   def verify_a_proof() do
     {frontiers, root} = generate_a_proof()
     MerkleTree.verify_proof(:crypto.hash(:sha256, "b"), frontiers, root)
+  end
+
+  def random_tree() do
+    leaves_length = :rand.uniform(7000) + 500
+
+    # For uniqueness of leaves, introduce initial bytes to hash
+    initial_leaf = :crypto.strong_rand_bytes(32)
+
+    leaves =
+      for _i <- 2..leaves_length, reduce: [initial_leaf] do
+        [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+      end
+
+    new_tree = MerkleTree.add(empty_tree(), leaves)
+
+    # Check that the leaves are as expected
+    assert List.starts_with?(Map.get(new_tree.nodes, 0), leaves)
+
+    # Check that index is as expected
+    assert new_tree.next_index == leaves_length
+
+    # Check that the capacity is as expected
+    expected_depth = (leaves_length |> :math.log2() |> trunc()) + 1
+    assert new_tree.capacity == 2 ** expected_depth
+    assert MerkleTree.depth(new_tree) == expected_depth
+
+    new_tree
   end
 end

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -2,6 +2,7 @@ defmodule Examples.EMerkleTree do
   require ExUnit.Assertions
   import ExUnit.Assertions
   alias Anoma.LocalDomain.MerkleTree
+  alias Anoma.LocalDomain.MerkleTreeChunk
 
   def empty_tree() do
     MerkleTree.new()
@@ -118,5 +119,34 @@ defmodule Examples.EMerkleTree do
       end
 
     MerkleTree.add(tree, leaves)
+  end
+
+  def block_with_hundred_commits() do
+    initial_leaf = :crypto.strong_rand_bytes(32)
+
+    for _i <- 2..300, reduce: [initial_leaf] do
+      [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+    end
+  end
+
+  def five_k_blocks(tree, block) do
+    for _i <- 1..5000, reduce: tree do
+      tree -> MerkleTree.add(tree, block)
+    end
+  end
+
+  def merkle_tree_differential() do
+    tree1 = MerkleTree.new()
+    tree2 = MerkleTreeChunk.new()
+
+    for i <- 1..300000, reduce: {tree1, tree2} do
+      {tree1, tree2} ->
+        leaf = :crypto.hash(:sha256, :erlang.term_to_binary(i))
+        upd_tree1 = MerkleTree.add(tree1, [leaf])
+        upd_tree2 = MerkleTreeChunk.add(tree2, [leaf])
+        assert MerkleTree.root(upd_tree1) == MerkleTreeChunk.root(upd_tree2)
+
+        {upd_tree1, upd_tree2}
+    end
   end
 end

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -149,4 +149,38 @@ defmodule Examples.EMerkleTree do
         {upd_tree1, upd_tree2}
     end
   end
+
+  def block(number) do
+    initial_leaf = :crypto.strong_rand_bytes(32)
+
+    for _i <- 2..number, reduce: [initial_leaf] do
+      [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+    end
+  end
+
+  def merkle_tree_comparisson(block_size, block_number) do
+    tree1 = MerkleTree.new()
+    tree2 = MerkleTreeChunk.new()
+
+   {{t1, _}, {t2, _}} =  for _i <- 1..block_number, reduce: {{0, tree1}, {0, tree2}} do
+      {{time1, tree1}, {time2, tree2}} ->
+        block = block(block_size)
+        {time_tree1, upd_tree1} = :timer.tc(fn -> MerkleTree.add(tree1, block) end)
+        {time_tree2, upd_tree2} = :timer.tc(fn -> MerkleTreeChunk.add(tree2, block) end)
+
+        {{time1 + time_tree1, upd_tree1}, {time2 + time_tree2, upd_tree2}}
+    end
+
+    if t1 > t2 do
+      IO.puts("Batch Approach is Faster")
+      IO.puts("Block size: #{inspect(block_size)}")
+      IO.puts("Block number: #{inspect(block_number)}")
+      IO.puts("Time factor difference: #{inspect(t1 / t2)}")
+    else
+      IO.puts("Sequential Approach is Faster")
+      IO.puts("Block size: #{inspect(block_size)}")
+      IO.puts("Block number: #{inspect(block_number)}")
+      IO.puts("Time factor difference: #{inspect(t2 / t1)}")
+    end
+  end
 end

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -65,10 +65,11 @@ defmodule Examples.EMerkleTree do
 
     new_tree = MerkleTree.add(empty_tree(), leaves)
 
-    sorted_leaves = Map.get(new_tree.nodes, 0)
-    |> Map.to_list()
-    |> Enum.sort(fn {ind1, _}, {ind2, _} -> ind1 < ind2 end)
-    |> Enum.map(&(elem(&1, 1)))
+    sorted_leaves =
+      Map.get(new_tree.nodes, 0)
+      |> Map.to_list()
+      |> Enum.sort(fn {ind1, _}, {ind2, _} -> ind1 < ind2 end)
+      |> Enum.map(&elem(&1, 1))
 
     # Check that the leaves are as expected
     assert List.starts_with?(sorted_leaves, leaves)
@@ -82,5 +83,40 @@ defmodule Examples.EMerkleTree do
     assert MerkleTree.depth(new_tree) == expected_depth
 
     new_tree
+  end
+
+  def add_100k_leaves() do
+    initial_leaf = :crypto.hash(:sha256, "25 k")
+
+    leaves =
+      for _i <- 2..100_000, reduce: [initial_leaf] do
+        [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+      end
+
+    MerkleTree.add(empty_tree(), leaves)
+  end
+
+  def add_100k_leaves_on_top() do
+    tree = add_100k_leaves()
+    initial_leaf = :crypto.hash(:sha256, "another one")
+
+    leaves =
+      for _i <- 2..100_000, reduce: [initial_leaf] do
+        [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+      end
+
+    MerkleTree.add(tree, leaves)
+  end
+
+  def add_100k_leaves_more_on_top() do
+    tree = add_100k_leaves_on_top()
+    initial_leaf = :crypto.hash(:sha256, "and another one")
+
+    leaves =
+      for _i <- 2..100_000, reduce: [initial_leaf] do
+        [hd | tl] -> [:crypto.hash(:sha256, hd) | [hd | tl]]
+      end
+
+    MerkleTree.add(tree, leaves)
   end
 end

--- a/lib/examples/e_merkle_tree.ex
+++ b/lib/examples/e_merkle_tree.ex
@@ -144,7 +144,9 @@ defmodule Examples.EMerkleTree do
         leaf = :crypto.hash(:sha256, :erlang.term_to_binary(i))
         upd_tree1 = MerkleTree.add(tree1, [leaf])
         upd_tree2 = MerkleTreeChunk.add(tree2, [leaf])
-        assert MerkleTree.root(upd_tree1) == MerkleTreeChunk.root(upd_tree2)
+
+        assert MerkleTree.root(upd_tree1) ==
+                 MerkleTreeChunk.root(upd_tree2)
 
         {upd_tree1, upd_tree2}
     end
@@ -158,27 +160,47 @@ defmodule Examples.EMerkleTree do
     end
   end
 
-  def merkle_tree_comparisson(initial_commitment_size, block_size, block_number) do
-    {initial_tree1, initial_tree2} = merkle_tree_differential(initial_commitment_size)
+  def merkle_tree_comparisson(
+        initial_commitment_size,
+        block_size,
+        block_number
+      ) do
+    {initial_tree1, initial_tree2} =
+      merkle_tree_differential(initial_commitment_size)
 
-   {{t1, _}, {t2, _}} =  for _i <- 1..block_number, reduce: {{0, initial_tree1}, {0, initial_tree2}} do
-      {{time1, tree1}, {time2, tree2}} ->
-        block = block(block_size)
-        {time_tree1, upd_tree1} = :timer.tc(fn -> MerkleTree.add(tree1, block) end)
-        {time_tree2, upd_tree2} = :timer.tc(fn -> MerkleTreeChunk.add(tree2, block) end)
+    {{t1, _}, {t2, _}} =
+      for _i <- 1..block_number,
+          reduce: {{0, initial_tree1}, {0, initial_tree2}} do
+        {{time1, tree1}, {time2, tree2}} ->
+          block = block(block_size)
 
-        {{time1 + time_tree1, upd_tree1}, {time2 + time_tree2, upd_tree2}}
-    end
+          {time_tree1, upd_tree1} =
+            :timer.tc(fn -> MerkleTree.add(tree1, block) end)
+
+          {time_tree2, upd_tree2} =
+            :timer.tc(fn -> MerkleTreeChunk.add(tree2, block) end)
+
+          {{time1 + time_tree1, upd_tree1},
+           {time2 + time_tree2, upd_tree2}}
+      end
 
     if t1 > t2 do
       IO.puts("Batch Approach is Faster")
-      IO.puts("Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}")
+
+      IO.puts(
+        "Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}"
+      )
+
       IO.puts("Block size: #{inspect(block_size)}")
       IO.puts("Block number: #{inspect(block_number)}")
       IO.puts("Time factor difference: #{inspect(t1 / t2)}")
     else
       IO.puts("Sequential Approach is Faster")
-      IO.puts("Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}")
+
+      IO.puts(
+        "Initial tree depth: #{inspect(MerkleTree.depth(initial_tree1))}"
+      )
+
       IO.puts("Block size: #{inspect(block_size)}")
       IO.puts("Block number: #{inspect(block_number)}")
       IO.puts("Time factor difference: #{inspect(t2 / t1)}")

--- a/lib/local_domain/structures/merkle_tree.ex
+++ b/lib/local_domain/structures/merkle_tree.ex
@@ -17,6 +17,7 @@ defmodule Anoma.LocalDomain.MerkleTree do
         0 => %{0 => :crypto.hash(:sha256, "EMPTY")}
       }
     )
+
     field(:next_index, non_neg_integer(), default: 0)
     field(:capacity, non_neg_integer(), default: 1)
   end
@@ -64,7 +65,7 @@ defmodule Anoma.LocalDomain.MerkleTree do
 
         _ ->
           false
-    end)
+      end)
 
     {path, root, _index} =
       for i <- 0..(depth(tree) - 1), reduce: {[], leaf, leaf_index} do
@@ -84,7 +85,7 @@ defmodule Anoma.LocalDomain.MerkleTree do
              div(index, 2)}
           else
             # If the node is a right one, take its left sibling
-             sibling = Map.get(current_nodes, index - 1, empty())
+            sibling = Map.get(current_nodes, index - 1, empty())
 
             # Hash the node on the right and sibling on the left
             # The index of its parents is going to be (index - 1) / 2
@@ -121,8 +122,8 @@ defmodule Anoma.LocalDomain.MerkleTree do
     new_nodes = compute_nodes(depth, tree.nodes, index, leaf)
 
     if index + 1 == tree.capacity do
-               # If the tree is fully filled, we need to recompute a new
-               # root as if by adding an extra empty leaf at next index
+      # If the tree is fully filled, we need to recompute a new
+      # root as if by adding an extra empty leaf at next index
       expanded_nodes =
         compute_nodes(depth + 1, new_nodes, index + 1, empty())
 
@@ -161,7 +162,7 @@ defmodule Anoma.LocalDomain.MerkleTree do
           else
             # If the node is a right one, fetch its left sibling
             sibling = Map.get(current_nodes, index - 1)
-             # Hash the node on the left and sibling on the right
+            # Hash the node on the left and sibling on the right
             # The index of its parents is going to be (index - 1) / 2
             {updated_nodes, div(index - 1, 2), hash(sibling <> node)}
           end

--- a/lib/local_domain/structures/merkle_tree.ex
+++ b/lib/local_domain/structures/merkle_tree.ex
@@ -33,11 +33,21 @@ defmodule Anoma.LocalDomain.MerkleTree do
 
   def new() do
     # Assume we have a tree at most of depth 32
-    empty_nodes =  for i <- 1..31, reduce: %{0 => :crypto.hash(:sha256, "EMPTY")} do
-      acc ->
-        previous_empty_hash = Map.get(acc, i - 1)
-        Map.put(acc, i, :crypto.hash(:sha256, previous_empty_hash <> previous_empty_hash))
-    end
+    empty_nodes =
+      for i <- 1..31, reduce: %{0 => :crypto.hash(:sha256, "EMPTY")} do
+        acc ->
+          previous_empty_hash = Map.get(acc, i - 1)
+
+          Map.put(
+            acc,
+            i,
+            :crypto.hash(
+              :sha256,
+              previous_empty_hash <> previous_empty_hash
+            )
+          )
+      end
+
     %Anoma.LocalDomain.MerkleTree{empty_nodes: empty_nodes}
   end
 
@@ -126,13 +136,20 @@ defmodule Anoma.LocalDomain.MerkleTree do
     depth = depth(tree)
 
     # Add a leaf and recompute needed intermediary nodes
-    new_nodes = compute_nodes(depth, tree.nodes, tree.empty_nodes, index, leaf)
+    new_nodes =
+      compute_nodes(depth, tree.nodes, tree.empty_nodes, index, leaf)
 
     if index + 1 == tree.capacity do
       # If the tree is fully filled, we need to recompute a new
       # root as if by adding an extra empty leaf at next index
       expanded_nodes =
-        compute_nodes(depth + 1, new_nodes, tree.empty_nodes, index + 1, empty())
+        compute_nodes(
+          depth + 1,
+          new_nodes,
+          tree.empty_nodes,
+          index + 1,
+          empty()
+        )
 
       %MerkleTree{
         tree
@@ -162,7 +179,9 @@ defmodule Anoma.LocalDomain.MerkleTree do
 
           if is_left do
             # If the node is a left one, fetch its right sibling
-            sibling = Map.get(current_nodes, index + 1, Map.get(empty_nodes, i))
+            sibling =
+              Map.get(current_nodes, index + 1, Map.get(empty_nodes, i))
+
             # Hash the node on the left and sibling on the right
             # The index of its parents is going to be index / 2
             {updated_nodes, div(index, 2), hash(node <> sibling)}

--- a/lib/local_domain/structures/merkle_tree.ex
+++ b/lib/local_domain/structures/merkle_tree.ex
@@ -14,6 +14,9 @@ defmodule Anoma.LocalDomain.MerkleTree do
         0 => [:crypto.hash(:sha256, "EMPTY")]
       }
     )
+
+    field(:next_index, non_neg_integer(), default: 0)
+    field(:capacity, non_neg_integer(), default: 1)
   end
 
   def hash(bytes) do
@@ -40,40 +43,21 @@ defmodule Anoma.LocalDomain.MerkleTree do
     Enum.map(1..n, fn _ -> empty() end)
   end
 
-  def add_leaf(tree, leaf) do
-    leaves = Map.get(tree.nodes, 0)
-
-    leaf_index =
-      leaves
-      |> Enum.find_index(&(&1 == empty()))
-
-    new_leaves = List.replace_at(leaves, leaf_index, leaf)
-
-    if leaf_index + 1 == length(leaves) do
-      new_leaves ++ generate_empty_branch(length(leaves))
-    else
-      new_leaves
-    end
-  end
-
-  def calculate_nodes(leaves, i) do
-    next_level =
-      Enum.chunk_every(leaves, 2, 2, :discard)
-      |> Enum.map(fn [a, b] -> hash(a <> b) end)
-
-    if length(next_level) > 1 do
-      Map.merge(%{i => next_level}, calculate_nodes(next_level, i + 1))
-    else
-      %{i => next_level}
-    end
-  end
-
-  def add(tree, value) do
-    new_leaves = add_leaf(tree, value)
+  def add(tree, values) do
+    {new_leaves, next_index, capacity} =
+      Enum.reduce(
+        values,
+        {Map.get(tree.nodes, 0), tree.next_index, tree.capacity},
+        fn leaf, {new_leaves, next_index, new_capacity} ->
+          add_leaf(new_leaves, next_index, new_capacity, leaf)
+        end
+      )
 
     %Anoma.LocalDomain.MerkleTree{
       nodes:
-        Map.merge(%{0 => new_leaves}, calculate_nodes(new_leaves, 1))
+        Map.merge(%{0 => new_leaves}, calculate_nodes(new_leaves, 1)),
+      next_index: next_index,
+      capacity: capacity
     }
   end
 
@@ -118,5 +102,29 @@ defmodule Anoma.LocalDomain.MerkleTree do
       end)
 
     calculated_root == root
+  end
+
+  defp add_leaf(leaves, index, capacity, leaf) do
+    new_leaves = List.replace_at(leaves, index, leaf)
+    new_index = index + 1
+
+    if new_index == capacity do
+      {new_leaves ++ generate_empty_branch(length(leaves)), new_index,
+       capacity * 2}
+    else
+      {new_leaves, new_index, capacity}
+    end
+  end
+
+  defp calculate_nodes(leaves, i) do
+    next_level =
+      Enum.chunk_every(leaves, 2, 2, :discard)
+      |> Enum.map(fn [a, b] -> hash(a <> b) end)
+
+    if length(next_level) > 1 do
+      Map.merge(%{i => next_level}, calculate_nodes(next_level, i + 1))
+    else
+      %{i => next_level}
+    end
   end
 end

--- a/lib/local_domain/structures/merkle_tree.ex
+++ b/lib/local_domain/structures/merkle_tree.ex
@@ -8,13 +8,15 @@ defmodule Anoma.LocalDomain.MerkleTree do
   import Bitwise
   use TypedStruct
 
+  alias __MODULE__
+
   typedstruct enforce: true do
-    field(:nodes, %{integer() => list(binary())},
+    # map from levels to the map from index to the node
+    field(:nodes, %{integer() => %{integer() => binary()}},
       default: %{
-        0 => [:crypto.hash(:sha256, "EMPTY")]
+        0 => %{0 => :crypto.hash(:sha256, "EMPTY")}
       }
     )
-
     field(:next_index, non_neg_integer(), default: 0)
     field(:capacity, non_neg_integer(), default: 1)
   end
@@ -32,60 +34,67 @@ defmodule Anoma.LocalDomain.MerkleTree do
   end
 
   def depth(tree) do
-    length(Map.keys(tree.nodes)) - 1
+    tree.capacity |> :math.log2() |> trunc()
   end
 
   def root(tree) do
-    Enum.at(Map.get(tree.nodes, depth(tree)), 0)
-  end
-
-  def generate_empty_branch(n) do
-    Enum.map(1..n, fn _ -> empty() end)
+    Map.get(Map.get(tree.nodes, depth(tree)), 0)
   end
 
   def add(tree, values) do
-    {new_leaves, next_index, capacity} =
-      Enum.reduce(
-        values,
-        {Map.get(tree.nodes, 0), tree.next_index, tree.capacity},
-        fn leaf, {new_leaves, next_index, new_capacity} ->
-          add_leaf(new_leaves, next_index, new_capacity, leaf)
-        end
-      )
-
-    %Anoma.LocalDomain.MerkleTree{
-      nodes:
-        Map.merge(%{0 => new_leaves}, calculate_nodes(new_leaves, 1)),
-      next_index: next_index,
-      capacity: capacity
-    }
+    Enum.reduce(
+      values,
+      tree,
+      fn leaf, acc_tree ->
+        add_leaf(acc_tree, leaf)
+      end
+    )
   end
 
   def generate_proof(tree, leaf) do
-    {frontiers, root} =
-      for i <- 0..(depth(tree) - 1), reduce: {[], leaf} do
-        {acc, leaf} ->
-          leaves = Map.get(tree.nodes, i)
+    leaves = Map.get(tree.nodes, 0)
 
-          leaf_index =
-            leaves
-            |> Enum.find_index(&(&1 == leaf))
+    # Get the index of the leaf
+    {leaf_index, _} =
+      leaves
+      |> Map.to_list()
+      |> Enum.find(fn
+        {_, ^leaf} ->
+          true
 
-          is_left = (leaf_index &&& 1) == 0
+        _ ->
+          false
+    end)
+
+    {path, root, _index} =
+      for i <- 0..(depth(tree) - 1), reduce: {[], leaf, leaf_index} do
+        {path, node, index} ->
+          # Take the current level of the tree
+          current_nodes = Map.get(tree.nodes, i)
+
+          is_left = (index &&& 1) == 0
 
           if is_left do
-            neighbour = Enum.at(leaves, leaf_index + 1)
+            # If the node is a left one, take its right sibling
+            sibling = Map.get(current_nodes, index + 1, empty())
 
-            {acc ++ [{neighbour, true}], hash(leaf <> neighbour)}
+            # Hash the node on the left and sibling on the right
+            # The index of its parents is going to be index / 2
+            {path ++ [{sibling, true}], hash(node <> sibling),
+             div(index, 2)}
           else
-            neighbour = Enum.at(leaves, leaf_index - 1)
+            # If the node is a right one, take its left sibling
+             sibling = Map.get(current_nodes, index - 1, empty())
 
-            {acc ++ [{neighbour, false}], hash(neighbour <> leaf)}
+            # Hash the node on the right and sibling on the left
+            # The index of its parents is going to be (index - 1) / 2
+            {path ++ [{sibling, false}], hash(sibling <> node),
+             div(index - 1, 2)}
           end
       end
 
     if root == root(tree) do
-      {frontiers, root}
+      {path, root}
     else
       nil
     end
@@ -104,27 +113,60 @@ defmodule Anoma.LocalDomain.MerkleTree do
     calculated_root == root
   end
 
-  defp add_leaf(leaves, index, capacity, leaf) do
-    new_leaves = List.replace_at(leaves, index, leaf)
-    new_index = index + 1
+  defp add_leaf(tree, leaf) do
+    index = tree.next_index
+    depth = depth(tree)
 
-    if new_index == capacity do
-      {new_leaves ++ generate_empty_branch(length(leaves)), new_index,
-       capacity * 2}
+    # Add a leaf and recompute needed intermediary nodes
+    new_nodes = compute_nodes(depth, tree.nodes, index, leaf)
+
+    if index + 1 == tree.capacity do
+               # If the tree is fully filled, we need to recompute a new
+               # root as if by adding an extra empty leaf at next index
+      expanded_nodes =
+        compute_nodes(depth + 1, new_nodes, index + 1, empty())
+
+      %MerkleTree{
+        tree
+        | nodes: expanded_nodes,
+          next_index: index + 1,
+          capacity: tree.capacity * 2
+      }
     else
-      {new_leaves, new_index, capacity}
+      %MerkleTree{tree | nodes: new_nodes, next_index: index + 1}
     end
   end
 
-  defp calculate_nodes(leaves, i) do
-    next_level =
-      Enum.chunk_every(leaves, 2, 2, :discard)
-      |> Enum.map(fn [a, b] -> hash(a <> b) end)
+  defp compute_nodes(depth, nodes, index, leaf) do
+    # Iterate over each level of the tree, updating
+    # only the parent nodes of the leaf
+    {new_nodes, _, _} =
+      for i <- 0..depth, reduce: {nodes, index, leaf} do
+        {acc_nodes, index, node} ->
+          # Fetch the current level of the tree
+          current_nodes = Map.get(acc_nodes, i, %{})
 
-    if length(next_level) > 1 do
-      Map.merge(%{i => next_level}, calculate_nodes(next_level, i + 1))
-    else
-      %{i => next_level}
-    end
+          # Put the updated node at the given index
+          updated_nodes =
+            Map.put(acc_nodes, i, Map.put(current_nodes, index, node))
+
+          is_left = (index &&& 1) == 0
+
+          if is_left do
+            # If the node is a left one, fetch its right sibling
+            sibling = Map.get(current_nodes, index + 1, empty())
+            # Hash the node on the left and sibling on the right
+            # The index of its parents is going to be index / 2
+            {updated_nodes, div(index, 2), hash(node <> sibling)}
+          else
+            # If the node is a right one, fetch its left sibling
+            sibling = Map.get(current_nodes, index - 1)
+             # Hash the node on the left and sibling on the right
+            # The index of its parents is going to be (index - 1) / 2
+            {updated_nodes, div(index - 1, 2), hash(sibling <> node)}
+          end
+      end
+
+    new_nodes
   end
 end

--- a/lib/local_domain/structures/merkle_tree.ex
+++ b/lib/local_domain/structures/merkle_tree.ex
@@ -18,6 +18,7 @@ defmodule Anoma.LocalDomain.MerkleTree do
       }
     )
 
+    field(:empty_nodes, %{integer() => binary()})
     field(:next_index, non_neg_integer(), default: 0)
     field(:capacity, non_neg_integer(), default: 1)
   end
@@ -31,7 +32,13 @@ defmodule Anoma.LocalDomain.MerkleTree do
   end
 
   def new() do
-    %Anoma.LocalDomain.MerkleTree{}
+    # Assume we have a tree at most of depth 32
+    empty_nodes =  for i <- 1..31, reduce: %{0 => :crypto.hash(:sha256, "EMPTY")} do
+      acc ->
+        previous_empty_hash = Map.get(acc, i - 1)
+        Map.put(acc, i, :crypto.hash(:sha256, previous_empty_hash <> previous_empty_hash))
+    end
+    %Anoma.LocalDomain.MerkleTree{empty_nodes: empty_nodes}
   end
 
   def depth(tree) do
@@ -119,13 +126,13 @@ defmodule Anoma.LocalDomain.MerkleTree do
     depth = depth(tree)
 
     # Add a leaf and recompute needed intermediary nodes
-    new_nodes = compute_nodes(depth, tree.nodes, index, leaf)
+    new_nodes = compute_nodes(depth, tree.nodes, tree.empty_nodes, index, leaf)
 
     if index + 1 == tree.capacity do
       # If the tree is fully filled, we need to recompute a new
       # root as if by adding an extra empty leaf at next index
       expanded_nodes =
-        compute_nodes(depth + 1, new_nodes, index + 1, empty())
+        compute_nodes(depth + 1, new_nodes, tree.empty_nodes, index + 1, empty())
 
       %MerkleTree{
         tree
@@ -138,7 +145,7 @@ defmodule Anoma.LocalDomain.MerkleTree do
     end
   end
 
-  defp compute_nodes(depth, nodes, index, leaf) do
+  defp compute_nodes(depth, nodes, empty_nodes, index, leaf) do
     # Iterate over each level of the tree, updating
     # only the parent nodes of the leaf
     {new_nodes, _, _} =
@@ -155,7 +162,7 @@ defmodule Anoma.LocalDomain.MerkleTree do
 
           if is_left do
             # If the node is a left one, fetch its right sibling
-            sibling = Map.get(current_nodes, index + 1, empty())
+            sibling = Map.get(current_nodes, index + 1, Map.get(empty_nodes, i))
             # Hash the node on the left and sibling on the right
             # The index of its parents is going to be index / 2
             {updated_nodes, div(index, 2), hash(node <> sibling)}

--- a/lib/local_domain/structures/merkle_tree.ex
+++ b/lib/local_domain/structures/merkle_tree.ex
@@ -1,0 +1,122 @@
+defmodule Anoma.LocalDomain.MerkleTree do
+  @moduledoc """
+  I implement merkle tree behaviour for use within local domain applications.
+
+  Has a variable depth.
+  """
+
+  import Bitwise
+  use TypedStruct
+
+  typedstruct enforce: true do
+    field(:nodes, %{integer() => list(binary())},
+      default: %{
+        0 => [:crypto.hash(:sha256, "EMPTY")]
+      }
+    )
+  end
+
+  def hash(bytes) do
+    :crypto.hash(:sha256, bytes)
+  end
+
+  def empty() do
+    hash("EMPTY")
+  end
+
+  def new() do
+    %Anoma.LocalDomain.MerkleTree{}
+  end
+
+  def depth(tree) do
+    length(Map.keys(tree.nodes)) - 1
+  end
+
+  def root(tree) do
+    Enum.at(Map.get(tree.nodes, depth(tree)), 0)
+  end
+
+  def generate_empty_branch(n) do
+    Enum.map(1..n, fn _ -> empty() end)
+  end
+
+  def add_leaf(tree, leaf) do
+    leaves = Map.get(tree.nodes, 0)
+
+    leaf_index =
+      leaves
+      |> Enum.find_index(&(&1 == empty()))
+
+    new_leaves = List.replace_at(leaves, leaf_index, leaf)
+
+    if leaf_index + 1 == length(leaves) do
+      new_leaves ++ generate_empty_branch(length(leaves))
+    else
+      new_leaves
+    end
+  end
+
+  def calculate_nodes(leaves, i) do
+    next_level =
+      Enum.chunk_every(leaves, 2, 2, :discard)
+      |> Enum.map(fn [a, b] -> hash(a <> b) end)
+
+    if length(next_level) > 1 do
+      Map.merge(%{i => next_level}, calculate_nodes(next_level, i + 1))
+    else
+      %{i => next_level}
+    end
+  end
+
+  def add(tree, value) do
+    new_leaves = add_leaf(tree, value)
+
+    %Anoma.LocalDomain.MerkleTree{
+      nodes:
+        Map.merge(%{0 => new_leaves}, calculate_nodes(new_leaves, 1))
+    }
+  end
+
+  def generate_proof(tree, leaf) do
+    {frontiers, root} =
+      for i <- 0..(depth(tree) - 1), reduce: {[], leaf} do
+        {acc, leaf} ->
+          leaves = Map.get(tree.nodes, i)
+
+          leaf_index =
+            leaves
+            |> Enum.find_index(&(&1 == leaf))
+
+          is_left = (leaf_index &&& 1) == 0
+
+          if is_left do
+            neighbour = Enum.at(leaves, leaf_index + 1)
+
+            {acc ++ [{neighbour, true}], hash(leaf <> neighbour)}
+          else
+            neighbour = Enum.at(leaves, leaf_index - 1)
+
+            {acc ++ [{neighbour, false}], hash(neighbour <> leaf)}
+          end
+      end
+
+    if root == root(tree) do
+      {frontiers, root}
+    else
+      nil
+    end
+  end
+
+  def verify_proof(leaf, frontiers, root) do
+    calculated_root =
+      Enum.reduce(frontiers, leaf, fn {neighbour, is_left}, acc ->
+        if is_left do
+          hash(acc <> neighbour)
+        else
+          hash(neighbour <> acc)
+        end
+      end)
+
+    calculated_root == root
+  end
+end

--- a/lib/local_domain/structures/merkle_tree_batch.ex
+++ b/lib/local_domain/structures/merkle_tree_batch.ex
@@ -21,6 +21,10 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
     field(:empty_nodes, %{integer() => binary()})
     field(:next_index, non_neg_integer(), default: 0)
     field(:capacity, non_neg_integer(), default: 1)
+
+    # leaf map with leaves as keys
+    # for efficient path computation
+    field(:leaf_map, %{binary() => integer()}, default: %{})
   end
 
   def hash(bytes) do
@@ -61,7 +65,14 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
 
   def add(tree, leaves) do
     index = tree.next_index
-    new_commitment_length = index + length(leaves)
+
+    # Compute the new leaf map and new commitment length
+    # in the same loop
+    {new_leaf_map, new_commitment_length} =
+      for leaf <- leaves, reduce: {tree.leaf_map, index} do
+        {map_acc, index_acc} ->
+          {Map.put(map_acc, index_acc, leaf), index + 1}
+      end
 
     {depth, capacity} =
       if new_commitment_length >= tree.capacity do
@@ -82,24 +93,14 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
       tree
       | nodes: new_nodes,
         next_index: new_commitment_length,
-        capacity: capacity
+        capacity: capacity,
+        leaf_map: new_leaf_map
     }
   end
 
   def generate_proof(tree, leaf) do
-    leaves = Map.get(tree.nodes, 0)
-
     # Get the index of the leaf
-    {leaf_index, _} =
-      leaves
-      |> Map.to_list()
-      |> Enum.find(fn
-        {_, ^leaf} ->
-          true
-
-        _ ->
-          false
-      end)
+    leaf_index = Map.get(tree.leaf_map, leaf)
 
     {path, root, _index} =
       for i <- 0..(depth(tree) - 1), reduce: {[], leaf, leaf_index} do

--- a/lib/local_domain/structures/merkle_tree_batch.ex
+++ b/lib/local_domain/structures/merkle_tree_batch.ex
@@ -33,11 +33,21 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
 
   def new() do
     # Assume we have a tree at most of depth 32
-   empty_nodes =  for i <- 1..31, reduce: %{0 => :crypto.hash(:sha256, "EMPTY")} do
-      acc ->
-        previous_empty_hash = Map.get(acc, i - 1)
-        Map.put(acc, i, :crypto.hash(:sha256, previous_empty_hash <> previous_empty_hash))
-    end
+    empty_nodes =
+      for i <- 1..31, reduce: %{0 => :crypto.hash(:sha256, "EMPTY")} do
+        acc ->
+          previous_empty_hash = Map.get(acc, i - 1)
+
+          Map.put(
+            acc,
+            i,
+            :crypto.hash(
+              :sha256,
+              previous_empty_hash <> previous_empty_hash
+            )
+          )
+      end
+
     %Anoma.LocalDomain.MerkleTreeChunk{empty_nodes: empty_nodes}
   end
 
@@ -63,8 +73,10 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
       else
         {depth(tree), tree.capacity}
       end
+
     # Add leaves and recompute needed intermediary nodes
-    new_nodes = compute_nodes(depth, tree.nodes, tree.empty_nodes, index, leaves)
+    new_nodes =
+      compute_nodes(depth, tree.nodes, tree.empty_nodes, index, leaves)
 
     %MerkleTreeChunk{
       tree
@@ -152,11 +164,12 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
               {Map.put(acc, k, node), k + 1}
             end)
 
-          {full_nodes, new_index} = if is_left(index) do
-            {nodes, index}
-          else
-            {[Map.get(current_nodes, index - 1) | nodes], index - 1}
-          end
+          {full_nodes, new_index} =
+            if is_left(index) do
+              {nodes, index}
+            else
+              {[Map.get(current_nodes, index - 1) | nodes], index - 1}
+            end
 
           # Calculate the parents of all the given nodes
           {parents, _, _} =
@@ -164,8 +177,15 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
               {parents, j, is_left} ->
                 if is_left do
                   # Get the right sibling
-                  sibling = Map.get(updated_nodes, j + 1, Map.get(empty_nodes, i))
-                  {parents ++ [hash(node <> sibling)], j + 1, not is_left}
+                  sibling =
+                    Map.get(
+                      updated_nodes,
+                      j + 1,
+                      Map.get(empty_nodes, i)
+                    )
+
+                  {parents ++ [hash(node <> sibling)], j + 1,
+                   not is_left}
                 else
                   {parents, j + 1, not is_left}
                 end
@@ -185,6 +205,6 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
   end
 
   defp is_left(index) do
-     (index &&& 1) == 0
+    (index &&& 1) == 0
   end
 end

--- a/lib/local_domain/structures/merkle_tree_batch.ex
+++ b/lib/local_domain/structures/merkle_tree_batch.ex
@@ -157,42 +157,46 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
           # Fetch the current level of the tree
           current_nodes = Map.get(acc_nodes, i, %{})
 
-          # Put the updated nodes as ordered by the list
-          {updated_nodes, _} =
-            Enum.reduce(nodes, {current_nodes, index}, fn node,
-                                                          {acc, k} ->
-              {Map.put(acc, k, node), k + 1}
-            end)
-
-          {full_nodes, new_index} =
+          # If the first node is the right one, fetch its sibling
+          initial_left_sibling =
             if is_left(index) do
-              {nodes, index}
+              nil
             else
-              {[Map.get(current_nodes, index - 1) | nodes], index - 1}
+              Map.get(current_nodes, index - 1)
             end
 
-          # Calculate the parents of all the given nodes
-          {parents, _, _} =
-            for node <- full_nodes, reduce: {[], new_index, true} do
-              {parents, j, is_left} ->
-                if is_left do
-                  # Get the right sibling
-                  sibling =
-                    Map.get(
-                      updated_nodes,
-                      j + 1,
-                      Map.get(empty_nodes, i)
-                    )
-
-                  {[hash(node <> sibling) | parents], j + 1,
-                   not is_left}
+          # Iterate over all the nodes
+          # Populate the current level with them
+          # Also calculate the list of parent nodes
+          {updated_current_nodes, parents, _, final_left_sibling} =
+            for node <- nodes,
+                reduce: {current_nodes, [], index, initial_left_sibling} do
+              {acc_current_nodes, parents, j, left_sibling} ->
+                if left_sibling do
+                  # Hash the left sibling with the current node
+                  {Map.put(acc_current_nodes, j, node),
+                   [hash(left_sibling <> node) | parents], j + 1, nil}
                 else
-                  {parents, j + 1, not is_left}
+                  # record the current node as a left sibling
+                  {Map.put(acc_current_nodes, j, node), parents, j + 1,
+                   node}
                 end
             end
 
-          {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
-           Enum.reverse(parents)}
+          # If the final node was a left one, we have to compute one more parent
+          # by hashing with an empty node of the appropriate level
+          final_parents =
+            if final_left_sibling do
+              [
+                hash(final_left_sibling <> Map.get(empty_nodes, i))
+                | parents
+              ]
+            else
+              parents
+            end
+
+          {Map.put(acc_nodes, i, updated_current_nodes), div(index, 2),
+           Enum.reverse(final_parents)}
       end
 
     new_nodes

--- a/lib/local_domain/structures/merkle_tree_batch.ex
+++ b/lib/local_domain/structures/merkle_tree_batch.ex
@@ -184,21 +184,15 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
                       Map.get(empty_nodes, i)
                     )
 
-                  {parents ++ [hash(node <> sibling)], j + 1,
+                  {[hash(node <> sibling) | parents], j + 1,
                    not is_left}
                 else
                   {parents, j + 1, not is_left}
                 end
             end
 
-          # If the next iteration is the final one, give only one parent, i.e. root
-          if i + 1 == depth do
-            {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
-             parents}
-          else
-            {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
-             parents}
-          end
+          {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
+           Enum.reverse(parents)}
       end
 
     new_nodes

--- a/lib/local_domain/structures/merkle_tree_batch.ex
+++ b/lib/local_domain/structures/merkle_tree_batch.ex
@@ -18,6 +18,7 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
       }
     )
 
+    field(:empty_nodes, %{integer() => binary()})
     field(:next_index, non_neg_integer(), default: 0)
     field(:capacity, non_neg_integer(), default: 1)
   end
@@ -31,7 +32,13 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
   end
 
   def new() do
-    %Anoma.LocalDomain.MerkleTreeChunk{}
+    # Assume we have a tree at most of depth 32
+   empty_nodes =  for i <- 1..31, reduce: %{0 => :crypto.hash(:sha256, "EMPTY")} do
+      acc ->
+        previous_empty_hash = Map.get(acc, i - 1)
+        Map.put(acc, i, :crypto.hash(:sha256, previous_empty_hash <> previous_empty_hash))
+    end
+    %Anoma.LocalDomain.MerkleTreeChunk{empty_nodes: empty_nodes}
   end
 
   def depth(tree) do
@@ -57,7 +64,7 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
         {depth(tree), tree.capacity}
       end
     # Add leaves and recompute needed intermediary nodes
-    new_nodes = compute_nodes(depth, tree.nodes, index, leaves)
+    new_nodes = compute_nodes(depth, tree.nodes, tree.empty_nodes, index, leaves)
 
     %MerkleTreeChunk{
       tree
@@ -129,7 +136,7 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
     calculated_root == root
   end
 
-  defp compute_nodes(depth, nodes, index, leaves) do
+  defp compute_nodes(depth, nodes, empty_nodes, index, leaves) do
     # Iterate over each level of the tree, updating
     # only the parent nodes of the given leaves
     {new_nodes, _, _} =
@@ -157,7 +164,7 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
               {parents, j, is_left} ->
                 if is_left do
                   # Get the right sibling
-                  sibling = Map.get(updated_nodes, j + 1, empty())
+                  sibling = Map.get(updated_nodes, j + 1, Map.get(empty_nodes, i))
                   {parents ++ [hash(node <> sibling)], j + 1, not is_left}
                 else
                   {parents, j + 1, not is_left}
@@ -167,7 +174,7 @@ defmodule Anoma.LocalDomain.MerkleTreeChunk do
           # If the next iteration is the final one, give only one parent, i.e. root
           if i + 1 == depth do
             {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
-             [hd(parents)]}
+             parents}
           else
             {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
              parents}

--- a/lib/local_domain/structures/merkle_tree_batch.ex
+++ b/lib/local_domain/structures/merkle_tree_batch.ex
@@ -1,0 +1,183 @@
+defmodule Anoma.LocalDomain.MerkleTreeChunk do
+  @moduledoc """
+  I implement merkle tree behaviour for use within local domain applications.
+
+  Has a variable depth.
+  """
+
+  import Bitwise
+  use TypedStruct
+
+  alias __MODULE__
+
+  typedstruct enforce: true do
+    # map from levels to the map from index to the node
+    field(:nodes, %{integer() => %{integer() => binary()}},
+      default: %{
+        0 => %{0 => :crypto.hash(:sha256, "EMPTY")}
+      }
+    )
+
+    field(:next_index, non_neg_integer(), default: 0)
+    field(:capacity, non_neg_integer(), default: 1)
+  end
+
+  def hash(bytes) do
+    :crypto.hash(:sha256, bytes)
+  end
+
+  def empty() do
+    hash("EMPTY")
+  end
+
+  def new() do
+    %Anoma.LocalDomain.MerkleTreeChunk{}
+  end
+
+  def depth(tree) do
+    tree.capacity |> :math.log2() |> trunc()
+  end
+
+  def root(tree) do
+    Map.get(Map.get(tree.nodes, depth(tree)), 0)
+  end
+
+  def add(tree, leaves) do
+    index = tree.next_index
+    new_commitment_length = index + length(leaves)
+
+    {depth, capacity} =
+      if new_commitment_length >= tree.capacity do
+        # If the tree capacity is exceeded, calculate the new minimal depth
+        new_depth =
+          (new_commitment_length |> :math.log2() |> trunc()) + 1
+
+        {new_depth, Integer.pow(2, new_depth)}
+      else
+        {depth(tree), tree.capacity}
+      end
+    # Add leaves and recompute needed intermediary nodes
+    new_nodes = compute_nodes(depth, tree.nodes, index, leaves)
+
+    %MerkleTreeChunk{
+      tree
+      | nodes: new_nodes,
+        next_index: new_commitment_length,
+        capacity: capacity
+    }
+  end
+
+  def generate_proof(tree, leaf) do
+    leaves = Map.get(tree.nodes, 0)
+
+    # Get the index of the leaf
+    {leaf_index, _} =
+      leaves
+      |> Map.to_list()
+      |> Enum.find(fn
+        {_, ^leaf} ->
+          true
+
+        _ ->
+          false
+      end)
+
+    {path, root, _index} =
+      for i <- 0..(depth(tree) - 1), reduce: {[], leaf, leaf_index} do
+        {path, node, index} ->
+          # Take the current level of the tree
+          current_nodes = Map.get(tree.nodes, i)
+
+          is_left = (index &&& 1) == 0
+
+          if is_left do
+            # If the node is a left one, take its right sibling
+            sibling = Map.get(current_nodes, index + 1, empty())
+
+            # Hash the node on the left and sibling on the right
+            # The index of its parents is going to be index / 2
+            {path ++ [{sibling, true}], hash(node <> sibling),
+             div(index, 2)}
+          else
+            # If the node is a right one, take its left sibling
+            sibling = Map.get(current_nodes, index - 1, empty())
+
+            # Hash the node on the right and sibling on the left
+            # The index of its parents is going to be (index - 1) / 2
+            {path ++ [{sibling, false}], hash(sibling <> node),
+             div(index - 1, 2)}
+          end
+      end
+
+    if root == root(tree) do
+      {path, root}
+    else
+      nil
+    end
+  end
+
+  def verify_proof(leaf, frontiers, root) do
+    calculated_root =
+      Enum.reduce(frontiers, leaf, fn {neighbour, is_left}, acc ->
+        if is_left do
+          hash(acc <> neighbour)
+        else
+          hash(neighbour <> acc)
+        end
+      end)
+
+    calculated_root == root
+  end
+
+  defp compute_nodes(depth, nodes, index, leaves) do
+    # Iterate over each level of the tree, updating
+    # only the parent nodes of the given leaves
+    {new_nodes, _, _} =
+      for i <- 0..depth, reduce: {nodes, index, leaves} do
+        {acc_nodes, index, nodes} ->
+          # Fetch the current level of the tree
+          current_nodes = Map.get(acc_nodes, i, %{})
+
+          # Put the updated nodes as ordered by the list
+          {updated_nodes, _} =
+            Enum.reduce(nodes, {current_nodes, index}, fn node,
+                                                          {acc, k} ->
+              {Map.put(acc, k, node), k + 1}
+            end)
+
+          {full_nodes, new_index} = if is_left(index) do
+            {nodes, index}
+          else
+            {[Map.get(current_nodes, index - 1) | nodes], index - 1}
+          end
+
+          # Calculate the parents of all the given nodes
+          {parents, _, _} =
+            for node <- full_nodes, reduce: {[], new_index, true} do
+              {parents, j, is_left} ->
+                if is_left do
+                  # Get the right sibling
+                  sibling = Map.get(updated_nodes, j + 1, empty())
+                  {parents ++ [hash(node <> sibling)], j + 1, not is_left}
+                else
+                  {parents, j + 1, not is_left}
+                end
+            end
+
+          # If the next iteration is the final one, give only one parent, i.e. root
+          if i + 1 == depth do
+            {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
+             [hd(parents)]}
+          else
+            {Map.put(acc_nodes, i, updated_nodes), div(index, 2),
+             parents}
+          end
+      end
+
+    new_nodes
+  end
+
+  defp is_left(index) do
+     (index &&& 1) == 0
+  end
+end

--- a/lib/local_domain/system/poller.ex
+++ b/lib/local_domain/system/poller.ex
@@ -44,28 +44,21 @@ defmodule Anoma.LocalDomain.System.Poller do
   def transactionExecutedQuery() do
     """
     query($min: Int!) {
-    ProtocolAdapter_TransactionExecuted(order_by: {blockNumber: desc}, where: {blockNumber:   {_gt: $min}}) {
-    id
-    tags
-    blockNumber
-    }
-    }
-    """
-  end
-
-  def payloadQuery() do
-    """
-    query($tags: [String!]!) {
-    ProtocolAdapter_DiscoveryPayload(where: {tag: {_in: $tags}}) {
-    id
-    blob
-    tag
-    }
-    ProtocolAdapter_ResourcePayload(where: {tag: {_in: $tags}}) {
-    id
-    blob
-    tag
-    }
+      ProtocolAdapter_TransactionExecuted(where: {blockNumber: {_gt: $min}}, order_by: {blockNumber: desc}) {
+        transactions {
+          tag
+          isConsumed
+          resourcePayloads {
+            id
+            blob
+          }
+          discoveryPayloads {
+            id
+            blob
+          }
+        }
+        blockNumber
+      }
     }
     """
   end
@@ -268,23 +261,62 @@ defmodule Anoma.LocalDomain.System.Poller do
            }
          ) do
       {:ok, %{status: 200, body: body}} ->
-        transactions =
+        events =
           body["data"]["ProtocolAdapter_TransactionExecuted"]
 
-        if length(transactions) > 0 do
+        if length(events) > 0 do
           Logger.debug("New blocks found")
 
-          next_blockheight = Enum.at(transactions, 0)["blockNumber"]
+          next_blockheight = Enum.at(events, 0)["blockNumber"]
 
-          tags =
-            transactions
-            |> Enum.map(fn txs -> txs["tags"] end)
+          transactions =
+            events
+            |> Enum.map(fn event -> event["transactions"] end)
             |> Enum.concat()
+
+          for tx <- transactions do
+            Logger.debug("Writing tag resource #{tx["tag"]}")
+
+            write_transaction_resource(
+              node_id,
+              contract,
+              tx["tag"],
+              tx["discoveryPayloads"],
+              tx["resourcePayloads"],
+              tx["isConsumed"]
+            )
+
+            # Attempt decryption + store per cipher key
+            for keypair <- cipher_keypairs,
+                discovery_payload <- tx["discoveryPayloads"] do
+              "0x" <> blob = discovery_payload["blob"]
+
+              case can_decrypt(keypair, blob) do
+                :ok ->
+                  Logger.debug("CAN DECRYPT #{blob}")
+
+                  write_transaction_resource(
+                    node_id,
+                    contract,
+                    tx["tag"],
+                    keypair[:public_key],
+                    tx["discoveryPayloads"],
+                    tx["resourcePayloads"],
+                    tx["isConsumed"]
+                  )
+
+                {:error, reason} ->
+                  Logger.debug(
+                    "#{keypair[:public_key]} can't decrypt #{blob} #{inspect(reason)}"
+                  )
+              end
+            end
+          end
 
           write_blockheight(node_id, contract, next_blockheight)
 
           {:keep_state, %{data | blockheight: next_blockheight},
-           {:next_event, :internal, {:process_tags, tags}}}
+           {:state_timeout, 12_000, :tick}}
         else
           Logger.debug("No new blocks")
           {:keep_state, data, {:state_timeout, 12_000, :tick}}
@@ -294,93 +326,6 @@ defmodule Anoma.LocalDomain.System.Poller do
         Logger.error("Query failed #{inspect(reason)}")
         {:keep_state, data, {:state_timeout, 12_000, :tick}}
     end
-  end
-
-  @impl true
-  def handle_event(
-        :internal,
-        {:process_tags, tags},
-        :polling,
-        %{
-          endpoint: endpoint,
-          contract: contract,
-          cipher_keypairs: cipher_keypairs,
-          node_id: node_id
-        } = data
-      ) do
-    tags_with_indices = tags |> Enum.with_index()
-
-    case Req.post(endpoint,
-           json: %{query: payloadQuery(), variables: %{"tags" => tags}}
-         ) do
-      {:ok, %{status: 200, body: body}} ->
-        discovery_payloads =
-          body["data"]["ProtocolAdapter_DiscoveryPayload"]
-
-        resource_payloads =
-          body["data"]["ProtocolAdapter_ResourcePayload"]
-
-        for discovery_payload <- discovery_payloads do
-          resource_payloads =
-            Enum.filter(resource_payloads, fn p ->
-              p["tag"] == discovery_payload["tag"]
-            end)
-
-          Logger.debug(
-            "Found discovery payload for #{discovery_payload["tag"]}"
-          )
-
-          {_, index} =
-            Enum.find(tags_with_indices, fn {tag, _} ->
-              tag == discovery_payload["tag"]
-            end)
-
-          is_consumed =
-            case rem(index, 2) do
-              0 -> true
-              1 -> false
-            end
-
-          write_transaction_resource(
-            node_id,
-            contract,
-            discovery_payload["tag"],
-            discovery_payload,
-            resource_payloads,
-            is_consumed
-          )
-
-          # Attempt decryption + store per cipher key
-          for keypair <- cipher_keypairs do
-            "0x" <> blob = discovery_payload["blob"]
-
-            case can_decrypt(keypair, blob) do
-              :ok ->
-                Logger.debug("CAN DECRYPT #{blob}")
-
-                write_transaction_resource(
-                  node_id,
-                  contract,
-                  discovery_payload["tag"],
-                  keypair[:public_key],
-                  discovery_payload,
-                  resource_payloads,
-                  is_consumed
-                )
-
-              {:error, reason} ->
-                Logger.debug(
-                  "Failed to decrypt #{blob} #{inspect(reason)}"
-                )
-            end
-          end
-        end
-
-      reason ->
-        Logger.error("Query failed #{inspect(reason)}")
-    end
-
-    {:keep_state, data, {:state_timeout, 12_000, :tick}}
   end
 
   @impl true
@@ -417,29 +362,31 @@ defmodule Anoma.LocalDomain.System.Poller do
       {:ok, resource} =
         Anoma.LocalDomain.Storage.read_latest(node_id, resource_key)
 
-      "0x" <> blob = resource[:discovery]["blob"]
+      for discovery <- resource[:discovery] do
+        "0x" <> blob = discovery["blob"]
 
-      Logger.debug("Blob #{blob}")
+        Logger.debug("Blob #{blob}")
 
-      case can_decrypt(keypair, blob) do
-        :ok ->
-          Logger.debug("CAN DECRYPT #{blob}")
+        case can_decrypt(keypair, blob) do
+          :ok ->
+            Logger.debug("CAN DECRYPT #{blob}")
 
-          write_transaction_resource(
-            node_id,
-            contract,
-            List.last(resource_key),
-            keypair[:public_key],
-            resource[:discovery],
-            resource[:resource],
-            resource[:is_consumed]
-          )
+            write_transaction_resource(
+              node_id,
+              contract,
+              List.last(resource_key),
+              keypair[:public_key],
+              resource[:discovery],
+              resource[:resource],
+              resource[:is_consumed]
+            )
 
-        {:error, reason} ->
-          Logger.debug("Failed to decrypt #{blob} #{inspect(reason)}")
+          {:error, reason} ->
+            Logger.debug("Failed to decrypt #{blob} #{inspect(reason)}")
 
-        r ->
-          IO.puts(r)
+          r ->
+            IO.puts(r)
+        end
       end
     end
 

--- a/lib/local_domain/system/poller.ex
+++ b/lib/local_domain/system/poller.ex
@@ -302,53 +302,55 @@ defmodule Anoma.LocalDomain.System.Poller do
           Logger.debug("FOUND #{length(transactions)} TRANSACTIONS")
 
           next_tree =
-            for tx <- transactions, reduce: commitment_tree do
-              tree ->
-                Logger.debug("WRITING TAG RESOURCE #{tx["tag"]}")
+            Anoma.LocalDomain.MerkleTree.add(
+              commitment_tree,
+              transactions
+              |> Enum.filter(fn tx -> tx["is_consumed"] == false end)
+              |> Enum.map(fn tx ->
+                "0x" <> tag_hex = tx["tag"]
+                {:ok, tag_bin} = Base.decode16(tag_hex, case: :mixed)
+                tag_bin
+              end)
+            )
 
-                write_transaction_resource(
-                  node_id,
-                  contract,
-                  tx["tag"],
-                  tx["discoveryPayloads"],
-                  tx["resourcePayloads"],
-                  tx["isConsumed"]
-                )
+          for tx <- transactions do
+            Logger.debug("WRITING TAG RESOURCE #{tx["tag"]}")
 
-                # Attempt decryption + store per cipher key
-                for keypair <- cipher_keypairs,
-                    discovery_payload <- tx["discoveryPayloads"] do
-                  "0x" <> blob = discovery_payload["blob"]
+            write_transaction_resource(
+              node_id,
+              contract,
+              tx["tag"],
+              tx["discoveryPayloads"],
+              tx["resourcePayloads"],
+              tx["isConsumed"]
+            )
 
-                  case can_decrypt(keypair, blob) do
-                    :ok ->
-                      Logger.debug("CAN DECRYPT #{blob}")
+            # Attempt decryption + store per cipher key
+            for keypair <- cipher_keypairs,
+                discovery_payload <- tx["discoveryPayloads"] do
+              "0x" <> blob = discovery_payload["blob"]
 
-                      write_transaction_resource(
-                        node_id,
-                        contract,
-                        tx["tag"],
-                        keypair[:public_key],
-                        tx["discoveryPayloads"],
-                        tx["resourcePayloads"],
-                        tx["isConsumed"]
-                      )
+              case can_decrypt(keypair, blob) do
+                :ok ->
+                  Logger.debug("CAN DECRYPT #{blob}")
 
-                    {:error, reason} ->
-                      Logger.debug(
-                        "#{keypair[:public_key]} can't decrypt #{blob} #{inspect(reason)}"
-                      )
-                  end
-                end
+                  write_transaction_resource(
+                    node_id,
+                    contract,
+                    tx["tag"],
+                    keypair[:public_key],
+                    tx["discoveryPayloads"],
+                    tx["resourcePayloads"],
+                    tx["isConsumed"]
+                  )
 
-                if not tx["isConsumed"] do
-                  "0x" <> tag_hex = tx["tag"]
-                  {:ok, tag_bin} = Base.decode16(tag_hex, case: :mixed)
-                  Anoma.LocalDomain.MerkleTree.add(tree, tag_bin)
-                else
-                  tree
-                end
+                {:error, reason} ->
+                  Logger.debug(
+                    "#{keypair[:public_key]} can't decrypt #{blob} #{inspect(reason)}"
+                  )
+              end
             end
+          end
 
           write_commitment_tree(node_id, contract, next_tree)
           write_blockheight(node_id, contract, next_blockheight)

--- a/lib/local_domain/system/poller.ex
+++ b/lib/local_domain/system/poller.ex
@@ -11,6 +11,8 @@ defmodule Anoma.LocalDomain.System.Poller do
   Starts a poller for indexing a ProtocolAdapter contract
   """
   def start(node_id, contract, endpoint) do
+    Logger.debug("STARTING POLLER PROCESS")
+
     args = %{
       contract: contract,
       cipher_keypairs: [],
@@ -44,7 +46,7 @@ defmodule Anoma.LocalDomain.System.Poller do
   def transactionExecutedQuery() do
     """
     query($min: Int!) {
-      ProtocolAdapter_TransactionExecuted(where: {blockNumber: {_gt: $min}}, order_by: {blockNumber: desc}) {
+      ProtocolAdapter_TransactionExecuted(where: {blockNumber: {_gt: $min}}) {
         transactions {
           tag
           isConsumed
@@ -165,6 +167,21 @@ defmodule Anoma.LocalDomain.System.Poller do
     )
   end
 
+  def read_commitment_tree(node_id, contract) do
+    Anoma.LocalDomain.Storage.read_latest(
+      node_id,
+      ~k"/!contract/commitments"
+    )
+  end
+
+  def write_commitment_tree(node_id, contract, tree) do
+    Anoma.LocalDomain.Storage.write_local(
+      node_id,
+      ~k"/!contract/commitments",
+      tree
+    )
+  end
+
   def prepare_payload_and_keypair(
         payload_bytes,
         secret_key_bytes,
@@ -224,13 +241,20 @@ defmodule Anoma.LocalDomain.System.Poller do
   @impl true
   def init(opts) do
     data =
-      Map.put(
+      Map.merge(
         opts,
-        :blockheight,
-        case read_blockheight(opts[:node_id], opts[:contract]) do
-          {:ok, blockheight} -> blockheight
-          :absent -> 0
-        end
+        %{
+          blockheight:
+            case read_blockheight(opts[:node_id], opts[:contract]) do
+              {:ok, blockheight} -> blockheight
+              :absent -> 0
+            end,
+          commitments:
+            case read_commitment_tree(opts[:node_id], opts[:contract]) do
+              {:ok, tree} -> tree
+              :absent -> Anoma.LocalDomain.MerkleTree.new()
+            end
+        }
       )
 
     {:ok, :polling, data, {:state_timeout, 0, :tick}}
@@ -246,7 +270,8 @@ defmodule Anoma.LocalDomain.System.Poller do
           endpoint: endpoint,
           blockheight: current_blockheight,
           contract: contract,
-          node_id: node_id
+          node_id: node_id,
+          commitments: commitment_tree
         } = data
       ) do
     Logger.info("POLLING #{endpoint}")
@@ -267,56 +292,73 @@ defmodule Anoma.LocalDomain.System.Poller do
         if length(events) > 0 do
           Logger.debug("New blocks found")
 
-          next_blockheight = Enum.at(events, 0)["blockNumber"]
+          next_blockheight = Enum.at(events, -1)["blockNumber"]
 
           transactions =
             events
             |> Enum.map(fn event -> event["transactions"] end)
             |> Enum.concat()
 
-          for tx <- transactions do
-            Logger.debug("Writing tag resource #{tx["tag"]}")
+          Logger.debug("FOUND #{length(transactions)} TRANSACTIONS")
 
-            write_transaction_resource(
-              node_id,
-              contract,
-              tx["tag"],
-              tx["discoveryPayloads"],
-              tx["resourcePayloads"],
-              tx["isConsumed"]
-            )
+          next_tree =
+            for tx <- transactions, reduce: commitment_tree do
+              tree ->
+                Logger.debug("WRITING TAG RESOURCE #{tx["tag"]}")
 
-            # Attempt decryption + store per cipher key
-            for keypair <- cipher_keypairs,
-                discovery_payload <- tx["discoveryPayloads"] do
-              "0x" <> blob = discovery_payload["blob"]
+                write_transaction_resource(
+                  node_id,
+                  contract,
+                  tx["tag"],
+                  tx["discoveryPayloads"],
+                  tx["resourcePayloads"],
+                  tx["isConsumed"]
+                )
 
-              case can_decrypt(keypair, blob) do
-                :ok ->
-                  Logger.debug("CAN DECRYPT #{blob}")
+                # Attempt decryption + store per cipher key
+                for keypair <- cipher_keypairs,
+                    discovery_payload <- tx["discoveryPayloads"] do
+                  "0x" <> blob = discovery_payload["blob"]
 
-                  write_transaction_resource(
-                    node_id,
-                    contract,
-                    tx["tag"],
-                    keypair[:public_key],
-                    tx["discoveryPayloads"],
-                    tx["resourcePayloads"],
-                    tx["isConsumed"]
-                  )
+                  case can_decrypt(keypair, blob) do
+                    :ok ->
+                      Logger.debug("CAN DECRYPT #{blob}")
 
-                {:error, reason} ->
-                  Logger.debug(
-                    "#{keypair[:public_key]} can't decrypt #{blob} #{inspect(reason)}"
-                  )
-              end
+                      write_transaction_resource(
+                        node_id,
+                        contract,
+                        tx["tag"],
+                        keypair[:public_key],
+                        tx["discoveryPayloads"],
+                        tx["resourcePayloads"],
+                        tx["isConsumed"]
+                      )
+
+                    {:error, reason} ->
+                      Logger.debug(
+                        "#{keypair[:public_key]} can't decrypt #{blob} #{inspect(reason)}"
+                      )
+                  end
+                end
+
+                if not tx["isConsumed"] do
+                  "0x" <> tag_hex = tx["tag"]
+                  {:ok, tag_bin} = Base.decode16(tag_hex, case: :mixed)
+                  Anoma.LocalDomain.MerkleTree.add(tree, tag_bin)
+                else
+                  tree
+                end
             end
-          end
 
+          write_commitment_tree(node_id, contract, next_tree)
           write_blockheight(node_id, contract, next_blockheight)
 
-          {:keep_state, %{data | blockheight: next_blockheight},
-           {:state_timeout, 12_000, :tick}}
+          {:keep_state,
+           %{
+             data
+             | blockheight: next_blockheight,
+               commitments: next_tree
+           }, {:state_timeout, 12_000, :tick}}
         else
           Logger.debug("No new blocks")
           {:keep_state, data, {:state_timeout, 12_000, :tick}}

--- a/test/merkle_test.exs
+++ b/test/merkle_test.exs
@@ -3,10 +3,10 @@ defmodule MerkleTest do
   doctest Anoma.LocalDomain.MerkleTree
 
   test "Run the examples" do
-    Examples.EMerkleTree.add_leaf_to_merkle_tree
-    Examples.EMerkleTree.write_to_merkle_tree
-    Examples.EMerkleTree.expand_merkle_tree
-    Examples.EMerkleTree.generate_a_proof
-    Examples.EMerkleTree.verify_a_proof    
+    Examples.EMerkleTree.write_to_merkle_tree()
+    Examples.EMerkleTree.expand_merkle_tree()
+    Examples.EMerkleTree.generate_a_proof()
+    Examples.EMerkleTree.verify_a_proof()
+    Examples.EMerkleTree.random_tree()
   end
 end

--- a/test/merkle_test.exs
+++ b/test/merkle_test.exs
@@ -1,0 +1,12 @@
+defmodule MerkleTest do
+  use ExUnit.Case
+  doctest Anoma.LocalDomain.MerkleTree
+
+  test "Run the examples" do
+    Examples.EMerkleTree.add_leaf_to_merkle_tree
+    Examples.EMerkleTree.write_to_merkle_tree
+    Examples.EMerkleTree.expand_merkle_tree
+    Examples.EMerkleTree.generate_a_proof
+    Examples.EMerkleTree.verify_a_proof    
+  end
+end

--- a/test/poller_test.exs
+++ b/test/poller_test.exs
@@ -3,7 +3,7 @@ defmodule PollerTest do
   doctest Anoma.LocalDomain.System.Poller
 
   test "Run the examples" do
-    Examples.EPoller.decrypt_payload
-    Examples.EPoller.cipher_keypair_storage_retrieval
+    Examples.EPoller.decrypt_payload()
+    Examples.EPoller.cipher_keypair_storage_retrieval()
   end
 end


### PR DESCRIPTION
Tries to optimize merkle tree on two fronts:

- Store nodes as maps from their indices to binaries
  This ensures that we do not need to do any Enum `O(n)` operations in search of elements of lists
  
- Do not recompute nodes which are unchanged by the new leaves
  This decreases the complexity from `O(capacity)` to `O(number_of_new_leaves)`