### PR TITLE
Jam+murisi/feature/elixir resource machine

### DIFF
--- a/lib/examples/e_action.ex
+++ b/lib/examples/e_action.ex
@@ -36,7 +36,7 @@ defmodule Examples.EAction do
     consumed? = false
     logic = Map.get(obj, "logic")
 
-    result =
+    {result, env} =
       Anoma.LocalDomain.Scheme.eval([
         :apply,
         logic,

--- a/lib/examples/e_action.ex
+++ b/lib/examples/e_action.ex
@@ -37,7 +37,7 @@ defmodule Examples.EAction do
     logic = Map.get(obj, "logic")
 
     {result, _env} =
-      Anoma.LocalDomain.Scheme.eval([
+      Anoma.LocalDomain.Scheme.eval([[
         :apply,
         logic,
         [
@@ -46,7 +46,7 @@ defmodule Examples.EAction do
           unit,
           consumed?
         ]
-      ])
+      ]])
 
     assert result == true
 

--- a/lib/examples/e_action.ex
+++ b/lib/examples/e_action.ex
@@ -6,6 +6,7 @@ defmodule Examples.EAction do
   alias Anoma.LocalDomain.Action
 
   def transacted_inc() do
+    Anoma.LocalDomain.SchemeRegistry.register(Examples.EScheme)
     unit = Action.transact(Examples.EScheme.inc(2))
     created = Map.get(unit, :created)
     assert length(created) == 2
@@ -31,18 +32,16 @@ defmodule Examples.EAction do
 
   def interpret_inc_unit() do
     unit = unit_as_scheme()
-    obj = Enum.at(Map.get(unit, :created), 1)
+    obj = Enum.at(Map.get(unit, "created"), 1)
     consumed? = false
-    logic = Map.get(obj, :logic)
+    logic = Map.get(obj, "logic")
 
-    # IO.inspect(logic)
-    # IO.inspect(unit)
     result =
       Anoma.LocalDomain.Scheme.eval([
-        "apply",
+        :apply,
         logic,
         [
-          "list",
+          :list,
           obj,
           unit,
           consumed?

--- a/lib/examples/e_fixed_supply.ex
+++ b/lib/examples/e_fixed_supply.ex
@@ -28,6 +28,10 @@ defmodule Examples.EFixedSupply do
   end
 
   def transact_fixed_supply() do
+    Anoma.LocalDomain.SchemeRegistry.register(
+      Anoma.LocalDomain.FixedSupply
+    )
+
     fixed_supply = %FixedSupply{supply_quantity: 1000, quantity: 500}
 
     transaction =
@@ -55,16 +59,16 @@ defmodule Examples.EFixedSupply do
     transaction = transact_fixed_supply()
     unit = Action.to_scheme(transaction)
     # IO.inspect(unit)
-    obj = Enum.at(Map.get(unit, :consumed), 1)
+    obj = Enum.at(Map.get(unit, "consumed"), 1)
     consumed? = true
-    logic = Map.get(obj, :logic)
+    logic = Map.get(obj, "logic")
 
     result =
       Anoma.LocalDomain.Scheme.eval([
-        "apply",
+        :apply,
         logic,
         [
-          "list",
+          :list,
           obj,
           unit,
           consumed?
@@ -86,16 +90,16 @@ defmodule Examples.EFixedSupply do
   def interpret_quantity_scheme() do
     transaction = transact_fixed_supply()
     unit = Action.to_scheme(transaction)
-    obj = Enum.at(Map.get(unit, :created), 1)
+    obj = Enum.at(Map.get(unit, "created"), 1)
     consumed? = false
-    logic = Map.get(obj, :logic)
+    logic = Map.get(obj, "logic")
 
     result =
       Anoma.LocalDomain.Scheme.eval([
-        "apply",
+        :apply,
         logic,
         [
-          "list",
+          :list,
           obj,
           unit,
           consumed?

--- a/lib/examples/e_fixed_supply.ex
+++ b/lib/examples/e_fixed_supply.ex
@@ -67,7 +67,7 @@ defmodule Examples.EFixedSupply do
     logic = Map.get(obj, "logic")
     
     {result, _env} =
-      Anoma.LocalDomain.Scheme.eval([
+      Anoma.LocalDomain.Scheme.eval([[
         :apply,
         logic,
         [
@@ -76,7 +76,7 @@ defmodule Examples.EFixedSupply do
           unit,
           consumed?
         ]
-      ])
+      ]])
 
     assert result == true
 
@@ -98,7 +98,7 @@ defmodule Examples.EFixedSupply do
     logic = Map.get(obj, "logic")
 
     {result, _env} =
-      Anoma.LocalDomain.Scheme.eval([
+      Anoma.LocalDomain.Scheme.eval([[
         :apply,
         logic,
         [
@@ -107,7 +107,7 @@ defmodule Examples.EFixedSupply do
           unit,
           consumed?
         ]
-      ])
+      ]])
 
     assert result == true
 

--- a/lib/examples/e_fixed_supply.ex
+++ b/lib/examples/e_fixed_supply.ex
@@ -63,7 +63,7 @@ defmodule Examples.EFixedSupply do
     consumed? = true
     logic = Map.get(obj, "logic")
 
-    result =
+    {result, env} =
       Anoma.LocalDomain.Scheme.eval([
         :apply,
         logic,
@@ -94,7 +94,7 @@ defmodule Examples.EFixedSupply do
     consumed? = false
     logic = Map.get(obj, "logic")
 
-    result =
+    {result, env} =
       Anoma.LocalDomain.Scheme.eval([
         :apply,
         logic,

--- a/lib/examples/e_resource.ex
+++ b/lib/examples/e_resource.ex
@@ -22,7 +22,8 @@ defmodule Examples.EResource do
 
     assert r["logic"] ==
              [
-               :lambda,
+               :function,
+               :_,
                [:obj, :_instance, :_consumedp],
                [:is_integer, [:get, :obj, "data"]]
              ]

--- a/lib/examples/e_resource.ex
+++ b/lib/examples/e_resource.ex
@@ -20,11 +20,11 @@ defmodule Examples.EResource do
   def scheme_resource_int() do
     r = ObjToResource.scheme(obj_to_resource_int())
 
-    assert r[:logic] ==
+    assert r["logic"] ==
              [
-               "lambda",
-               ["obj", "_instance", "_consumedp"],
-               ["integer?", ["get", "obj", :data]]
+               :lambda,
+               [:obj, :_instance, :_consumedp],
+               [:is_integer, [:get, :obj, "data"]]
              ]
 
     r
@@ -38,7 +38,7 @@ defmodule Examples.EResource do
 
   def scheme_resource_built_in() do
     r = ObjToResource.scheme(obj_to_resource_built_in())
-    assert Map.get(r, :data) == "+"
+    assert Map.get(r, "data") == :+
     r
   end
 
@@ -62,14 +62,14 @@ defmodule Examples.EResource do
 
   def scheme_built_in() do
     r = ObjToResource.scheme(&Kernel.+/2)
-    assert r == "+"
+    assert r == :+
     r
   end
 
   def scheme_fn() do
-    {"closure", params, body} =
+    :inc =
       ObjToResource.scheme(&Examples.EScheme.inc/1)
 
-    {"closure", params, body}
+    :inc
   end
 end

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -7,55 +7,49 @@ defmodule Examples.EScheme do
 
   defrisc(inc(x), do: :erlang.+(x, 1))
 
-  defrisc inc_2(x) do
-    :erlang.+(x, 1) -> "inc"
-  end
-
-  defscheme(inc(x), do: ["+", "x", 1])
-
   def list() do
-    ["list", 1, 2, 3]
+    [:list, 1, 2, 3]
   end
 
   def dict() do
-    %{a: 3}
+    %{"a" => 3}
   end
 
   def lambda() do
-    ["lambda", ["a"], ["+", "a", 1]]
+    [:lambda, [:a], [:+, :a, 1]]
   end
 
   def apply() do
-    result = Scheme.eval(["apply", lambda(), ["list", 1]])
+    result = Scheme.eval([:apply, lambda(), [:list, 1]])
     assert result == 2
     result
   end
 
   def native_plus() do
-    result = Scheme.eval(["+", 1, 2])
+    result = Scheme.eval([:+, 1, 2])
     assert result == 3
     result
   end
 
-  def native_nth() do
-    expr = ["nth", list(), 2]
+  def native_at() do
+    expr = [:at, list(), 2]
     result = Scheme.eval(expr)
     assert result == 3
     result
   end
 
   def map() do
-    expr = ["map", list(), lambda()]
+    expr = [:map, list(), lambda()]
     result = Scheme.eval(expr)
-    assert result == ["list", 2, 3, 4]
+    assert result == [:list, 2, 3, 4]
     result
   end
 
   def apply_map() do
     expr = [
-      "apply",
-      ["lambda", ["x"], ["+", "x", 1]],
-      ["map", ["list", 1], ["lambda", ["x"], ["+", "x", 1]]]
+      :apply,
+      [:lambda, [:x], [:+, :x, 1]],
+      [:map, [:list, 1], [:lambda, [:x], [:+, :x, 1]]]
     ]
 
     result = Scheme.eval(expr)
@@ -64,46 +58,46 @@ defmodule Examples.EScheme do
   end
 
   def filter() do
-    filter = ["lambda", ["x"], ["==", "x", 1]]
-    expr = ["filter", list(), filter]
+    filter = [:lambda, [:x], [:==, :x, 1]]
+    expr = [:filter, list(), filter]
     result = Scheme.eval(expr)
-    assert result == ["list", 1]
+    assert result == [:list, 1]
     result
   end
 
   def nthcdr() do
-    expr = ["nthcdr", list(), 2]
+    expr = [:nthcdr, list(), 2]
     result = Scheme.eval(expr)
-    assert result == ["list", 3]
+    assert result == [:list, 3]
     result
   end
 
   def take() do
-    expr = ["take", list(), 2]
+    expr = [:take, list(), 2]
     result = Scheme.eval(expr)
-    assert result == ["list", 1, 2]
+    assert result == [:list, 1, 2]
     result
   end
 
   def get() do
-    result = Scheme.eval(["get", dict(), :a])
+    result = Scheme.eval([:get, dict(), "a"])
     result
   end
 
   def put() do
-    result = Scheme.eval(["put", dict(), :b, 1])
+    result = Scheme.eval([:put, dict(), "b", 1])
     result
   end
 
   def car() do
-    result = Scheme.eval(["car", list()])
+    result = Scheme.eval([:car, list()])
     assert result == 1
     result
   end
 
   def cdr() do
-    result = Scheme.eval(["cdr", list()])
-    assert result == ["list", 2, 3]
+    result = Scheme.eval([:cdr, list()])
+    assert result == [:list, 2, 3]
     result
   end
 
@@ -116,27 +110,27 @@ defmodule Examples.EScheme do
       )
 
     assert r == [
-             "lambda",
-             ["x"],
-             ["+", "x", 1]
+             :lambda,
+             [:x],
+             [:+, :x, 1]
            ]
 
     r
   end
 
   def get_to_scheme() do
-    ["get" | r] =
+    [:get | r] =
       Scheme.ast_to_scheme(
         quote do
           Map.get(%{a: %{b: 3}}, :a)
         end
       )
 
-    ["get" | r]
+    [:get | r]
   end
 
   def filter_to_scheme() do
-    ["filter" | r] =
+    [:filter | r] =
       Scheme.ast_to_scheme(
         quote do
           Enum.filter([1, 2, 3], fn finding ->
@@ -145,7 +139,7 @@ defmodule Examples.EScheme do
         end
       )
 
-    ["filter" | r]
+    [:filter | r]
   end
 
   def struct_to_scheme_no_template() do
@@ -160,7 +154,10 @@ defmodule Examples.EScheme do
 
     r = Scheme.ast_to_scheme(s)
     assert length(Map.keys(r)) == 4
-    assert Map.get(r, :__struct__) == Anoma.LocalDomain.Resource
+
+    assert Map.get(r, "__struct__") ==
+             "Elixir.Anoma.LocalDomain.Resource"
+
     r
   end
 
@@ -176,7 +173,10 @@ defmodule Examples.EScheme do
 
     r = Scheme.ast_to_scheme(s)
     assert length(Map.keys(r)) == 4
-    assert Map.get(r, :__struct__) == Anoma.LocalDomain.Resource
+
+    assert Map.get(r, "__struct__") ==
+             "Elixir.Anoma.LocalDomain.Resource"
+
     r
   end
 
@@ -192,12 +192,7 @@ defmodule Examples.EScheme do
 
     r = Scheme.ast_to_scheme(clause)
 
-    assert hd(r) == "if"
+    assert hd(r) == :if
     r
-  end
-
-  def get_scheme_registry_fails() do
-    {:ok, nil} =
-      Anoma.LocalDomain.SchemeRegistry.get_template(:erlang, "blah")
   end
 end

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -8,7 +8,7 @@ defmodule Examples.EScheme do
   defrisc(inc(x), do: :erlang.+(x, 1))
 
   def list() do
-    [:list, 1, 2, 3]
+    {:list, 1, 2, 3}
   end
 
   def dict() do

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -20,27 +20,27 @@ defmodule Examples.EScheme do
   end
 
   def apply() do
-    {result, _env} = Scheme.eval([:apply, lambda(), [:list, 1]])
+    {result, _env} = Scheme.eval([[:apply, lambda(), [:list, 1]]])
     assert result == 2
     result
   end
 
   def native_plus() do
-    {result, _env} = Scheme.eval([:+, 1, 2])
+    {result, _env} = Scheme.eval([[:+, 1, 2]])
     assert result == 3
     result
   end
 
   def native_at() do
     expr = [:at, list(), 2]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == 3
     result
   end
 
   def map() do
     expr = [:map, list(), lambda()]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [2, 3, 4]
     result
   end
@@ -52,7 +52,7 @@ defmodule Examples.EScheme do
       [:map, [:list, 1], [:function, :_, [:x], [:+, :x, 1]]]
     ]
 
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == 3
     result
   end
@@ -79,7 +79,7 @@ defmodule Examples.EScheme do
       ]
     ]
 
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == true
     result
   end
@@ -87,43 +87,43 @@ defmodule Examples.EScheme do
   def filter() do
     filter = [:function, :_, [:x], [:==, :x, 1]]
     expr = [:filter, list(), filter]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [1]
     result
   end
 
   def nthcdr() do
     expr = [:nthcdr, list(), 2]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [3]
     result
   end
 
   def take() do
     expr = [:take, list(), 2]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [1, 2]
     result
   end
 
   def get() do
-    result = Scheme.eval([:get, dict(), "a"])
+    result = Scheme.eval([[:get, dict(), "a"]])
     result
   end
 
   def put() do
-    result = Scheme.eval([:put, dict(), "b", 1])
+    result = Scheme.eval([[:put, dict(), "b", 1]])
     result
   end
 
   def car() do
-    {result, _env} = Scheme.eval([:car, list()])
+    {result, _env} = Scheme.eval([[:car, list()]])
     assert result == 1
     result
   end
 
   def cdr() do
-    {result, _env} = Scheme.eval([:cdr, list()])
+    {result, _env} = Scheme.eval([[:cdr, list()]])
     assert result == [2, 3]
     result
   end

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -101,6 +101,28 @@ defmodule Examples.EScheme do
     result
   end
 
+  def let() do
+    result = Scheme.eval([:let, :a, 3, [:+, :a, 1]])
+    assert result == 4
+    result
+  end
+
+  def function() do
+    result = Scheme.eval([:function, :dec, [:x], [:-, :x, 1]])
+    assert result == :dec
+    result
+  end
+
+  def do_macro() do
+    result = Scheme.eval([:do,
+                          [:function, :dec, [:x], [:-, :x, 1]],
+                          [:dec, 2]
+                         ])
+
+    assert result == 1
+    result
+  end
+
   def fn_to_scheme() do
     r =
       Scheme.ast_to_scheme(

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -20,27 +20,27 @@ defmodule Examples.EScheme do
   end
 
   def apply() do
-    result = Scheme.eval([:apply, lambda(), [:list, 1]])
+    {result, env} = Scheme.eval([:apply, lambda(), [:list, 1]])
     assert result == 2
     result
   end
 
   def native_plus() do
-    result = Scheme.eval([:+, 1, 2])
+    {result, env} = Scheme.eval([:+, 1, 2])
     assert result == 3
     result
   end
 
   def native_at() do
     expr = [:at, list(), 2]
-    result = Scheme.eval(expr)
+    {result, env} = Scheme.eval(expr)
     assert result == 3
     result
   end
 
   def map() do
     expr = [:map, list(), lambda()]
-    result = Scheme.eval(expr)
+    {result, env} = Scheme.eval(expr)
     assert result == [:list, 2, 3, 4]
     result
   end
@@ -52,7 +52,7 @@ defmodule Examples.EScheme do
       [:map, [:list, 1], [:lambda, [:x], [:+, :x, 1]]]
     ]
 
-    result = Scheme.eval(expr)
+    {result, env} = Scheme.eval(expr)
     assert result == 3
     result
   end
@@ -60,21 +60,21 @@ defmodule Examples.EScheme do
   def filter() do
     filter = [:lambda, [:x], [:==, :x, 1]]
     expr = [:filter, list(), filter]
-    result = Scheme.eval(expr)
+    {result, env} = Scheme.eval(expr)
     assert result == [:list, 1]
     result
   end
 
   def nthcdr() do
     expr = [:nthcdr, list(), 2]
-    result = Scheme.eval(expr)
+    {result, env} = Scheme.eval(expr)
     assert result == [:list, 3]
     result
   end
 
   def take() do
     expr = [:take, list(), 2]
-    result = Scheme.eval(expr)
+    {result, env} = Scheme.eval(expr)
     assert result == [:list, 1, 2]
     result
   end
@@ -90,13 +90,13 @@ defmodule Examples.EScheme do
   end
 
   def car() do
-    result = Scheme.eval([:car, list()])
+    {result, env} = Scheme.eval([:car, list()])
     assert result == 1
     result
   end
 
   def cdr() do
-    result = Scheme.eval([:cdr, list()])
+    {result, env} = Scheme.eval([:cdr, list()])
     assert result == [:list, 2, 3]
     result
   end

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -75,25 +75,20 @@ defmodule Examples.EScheme do
     expr = [
       [
         :function,
-        :_,
-        [],
-        [
-          :function,
-          :odd,
-          [:n],
-          [:if, [:==, :n, 0], false, [:even, [:-, :n, 1]]]
-        ],
-        [
-          :function,
-          :even,
-          [:n],
-          [:if, [:==, :n, 0], true, [:odd, [:-, :n, 1]]]
-        ],
-        [:even, 8]
-      ]
+        :odd,
+        [:n],
+        [:if, [:==, :n, 0], false, [:even, [:-, :n, 1]]]
+      ],
+      [
+        :function,
+        :even,
+        [:n],
+        [:if, [:==, :n, 0], true, [:odd, [:-, :n, 1]]]
+      ],
+      [:even, 8]
     ]
 
-    {result, _env} = Scheme.eval([expr])
+    {result, _env} = Scheme.eval(expr)
     assert result == true
     result
   end

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -41,7 +41,7 @@ defmodule Examples.EScheme do
   def map() do
     expr = [:map, list(), lambda()]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 2, 3, 4]
+    assert result == [2, 3, 4]
     result
   end
 
@@ -88,21 +88,21 @@ defmodule Examples.EScheme do
     filter = [:function, :_, [:x], [:==, :x, 1]]
     expr = [:filter, list(), filter]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 1]
+    assert result == [1]
     result
   end
 
   def nthcdr() do
     expr = [:nthcdr, list(), 2]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 3]
+    assert result == [3]
     result
   end
 
   def take() do
     expr = [:take, list(), 2]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 1, 2]
+    assert result == [1, 2]
     result
   end
 
@@ -124,7 +124,7 @@ defmodule Examples.EScheme do
 
   def cdr() do
     {result, _env} = Scheme.eval([:cdr, list()])
-    assert result == [:list, 2, 3]
+    assert result == [2, 3]
     result
   end
 

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -107,6 +107,26 @@ defmodule Examples.EScheme do
     result
   end
 
+  def labels() do
+    result = Scheme.eval([:labels, [[:is_even, [:x],
+                                     [:and,
+                                      [:>, :x, -1],
+                                      [:or,
+                                       [:==, :x, 0],
+                                       [:is_odd, [:-, :x, 1]]]]],
+                                    [:is_odd, [:x],
+                                     [:and,
+                                      [:>, :x, 0],
+                                      [:or,
+                                       [:==, :x, 1],
+                                       [:is_even, [:-, :x, 1]]]]]],
+                          [:is_even, 3]])
+
+    assert result == false
+
+    result
+  end
+
   def function() do
     result = Scheme.eval([:function, :dec, [:x], [:-, :x, 1]])
     assert result == :dec

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -16,7 +16,7 @@ defmodule Examples.EScheme do
   end
 
   def lambda() do
-    [:lambda, [:a], [:+, :a, 1]]
+    [:function, :_, [:a], [:+, :a, 1]]
   end
 
   def apply() do
@@ -48,8 +48,8 @@ defmodule Examples.EScheme do
   def apply_map() do
     expr = [
       :apply,
-      [:lambda, [:x], [:+, :x, 1]],
-      [:map, [:list, 1], [:lambda, [:x], [:+, :x, 1]]]
+      [:function, :_, [:x], [:+, :x, 1]],
+      [:map, [:list, 1], [:function, :_, [:x], [:+, :x, 1]]]
     ]
 
     {result, env} = Scheme.eval(expr)
@@ -57,8 +57,21 @@ defmodule Examples.EScheme do
     result
   end
 
+  def mutual_recursion() do
+    expr = [
+      [:function, :_, [],
+       [:function, :odd, [:n], [:if, [:==, :n, 0], false, [:even, [:-, :n, 1]]]],
+       [:function, :even, [:n], [:if, [:==, :n, 0], true, [:odd, [:-, :n, 1]]]],
+       [:even, 8]]
+    ]
+
+    {result, env} = Scheme.eval(expr)
+    assert result == true
+    result
+  end
+
   def filter() do
-    filter = [:lambda, [:x], [:==, :x, 1]]
+    filter = [:function, :_, [:x], [:==, :x, 1]]
     expr = [:filter, list(), filter]
     {result, env} = Scheme.eval(expr)
     assert result == [:list, 1]
@@ -110,7 +123,8 @@ defmodule Examples.EScheme do
       )
 
     assert r == [
-             :lambda,
+             :function,
+             :_,
              [:x],
              [:+, :x, 1]
            ]

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -31,6 +31,20 @@ defmodule Examples.EScheme do
     result
   end
 
+  def and_macro() do
+    {false, _env} = Scheme.eval([{:andm, :true, :false}])
+    {true, _env} = Scheme.eval([{:andm, :true, :true, :true}])
+    {false, _env} = Scheme.eval([{:andm, :false, :true}])
+    {false, _env} = Scheme.eval([{:andm, :false, :false}])
+  end
+
+  def or_macro() do
+    {true, _env} = Scheme.eval([{:orm, :true, :false}])
+    {true, _env} = Scheme.eval([{:orm, :true, :true, :true}])
+    {true, _env} = Scheme.eval([{:orm, :false, :true}])
+    {false, _env} = Scheme.eval([{:orm, :false, :false}])
+  end
+
   def native_at() do
     expr = [:at, list(), 2]
     {result, _env} = Scheme.eval([expr])

--- a/lib/examples/e_transpile.ex
+++ b/lib/examples/e_transpile.ex
@@ -5,13 +5,31 @@ defmodule Examples.ETranspile do
 
   def transpile_factorial() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :scm_main, [],
-       [:function, :factorial, [:n],
-        [:if, [:==, :n, 0],
-         1,
-         [:*, :n, [:factorial, [:-, :n, 1]]]]],
-        [:factorial, 5]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :scm_main,
+            [],
+            [
+              :function,
+              :factorial,
+              [:n],
+              [
+                :if,
+                [:==, :n, 0],
+                1,
+                [:*, :n, [:factorial, [:-, :n, 1]]]
+              ]
+            ],
+            [:factorial, 5]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -19,17 +37,56 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_filter() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :filter, [:xs, :f],
-        [:if, [:is_null, :xs],
-          [:null],
-          [:if, [:f, [:car, :xs]],
-            [:cons, [:car, :xs], [:filter, [:cdr, :xs], :f]],
-            [:filter, [:cdr, :xs], :f]]]],
-      [:function, :scm_main, [],
-        [[:function, :_, [:n],
-          [:commit_sexpr, [:filter, [:read_sexpr],
-            [:function, :divisible_by_n, [:x], [:==, [:%, [:as_integer, :x], :n], 0]]]]], 3]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :filter,
+            [:xs, :f],
+            [
+              :if,
+              [:is_null, :xs],
+              [:null],
+              [
+                :if,
+                [:f, [:car, :xs]],
+                [:cons, [:car, :xs], [:filter, [:cdr, :xs], :f]],
+                [:filter, [:cdr, :xs], :f]
+              ]
+            ]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [
+              [
+                :function,
+                :_,
+                [:n],
+                [
+                  :commit_sexpr,
+                  [
+                    :filter,
+                    [:read_sexpr],
+                    [
+                      :function,
+                      :divisible_by_n,
+                      [:x],
+                      [:==, [:%, [:as_integer, :x], :n], 0]
+                    ]
+                  ]
+                ]
+              ],
+              3
+            ]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -37,14 +94,39 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_take() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :take, [:xs, :n],
-        [:if, [:==, :n, 0],
-          [:null],
-          [:cons, [:car, :xs], [:take, [:cdr, :xs], [:-, :n, 1]]]]],
-      [:function, :scm_main, [],
-        [[:function, :_, [:n],
-          [:commit_sexpr, [:take, [:read_sexpr], :n]]], 3]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :take,
+            [:xs, :n],
+            [
+              :if,
+              [:==, :n, 0],
+              [:null],
+              [:cons, [:car, :xs], [:take, [:cdr, :xs], [:-, :n, 1]]]
+            ]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [
+              [
+                :function,
+                :_,
+                [:n],
+                [:commit_sexpr, [:take, [:read_sexpr], :n]]
+              ],
+              3
+            ]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -52,15 +134,51 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_map() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :map, [:xs, :f],
-        [:if, [:is_null, :xs],
-          [:null],
-          [:cons, [:f, [:car, :xs]], [:map, [:cdr, :xs], :f]]]],
-      [:function, :scm_main, [],
-        [[:function, :_, [:n],
-          [:commit_sexpr, [:map, [:read_sexpr],
-            [:function, :multiply_by_n, [:x], [:integer, [:*, [:as_integer, :x], :n]]]]]], 4]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :map,
+            [:xs, :f],
+            [
+              :if,
+              [:is_null, :xs],
+              [:null],
+              [:cons, [:f, [:car, :xs]], [:map, [:cdr, :xs], :f]]
+            ]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [
+              [
+                :function,
+                :_,
+                [:n],
+                [
+                  :commit_sexpr,
+                  [
+                    :map,
+                    [:read_sexpr],
+                    [
+                      :function,
+                      :multiply_by_n,
+                      [:x],
+                      [:integer, [:*, [:as_integer, :x], :n]]
+                    ]
+                  ]
+                ]
+              ],
+              4
+            ]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -68,13 +186,26 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_length() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :length, [:xs],
-        [:if, [:is_null, :xs],
-          0,
-          [:+, 1, [:length, [:cdr, :xs]]]]],
-      [:function, :scm_main, [],
-        [:commit_sexpr, [:integer, [:length, [:read_sexpr]]]]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :length,
+            [:xs],
+            [:if, [:is_null, :xs], 0, [:+, 1, [:length, [:cdr, :xs]]]]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [:commit_sexpr, [:integer, [:length, [:read_sexpr]]]]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -82,13 +213,31 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_nth() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :nth, [:xs, :n],
-        [:if, [:==, :n, 0],
-          [:car, :xs],
-          [:nth, [:cdr, :xs], [:-, :n, 1]]]],
-      [:function, :scm_main, [],
-        [:commit_sexpr, [:nth, [:read_sexpr], 8]]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :nth,
+            [:xs, :n],
+            [
+              :if,
+              [:==, :n, 0],
+              [:car, :xs],
+              [:nth, [:cdr, :xs], [:-, :n, 1]]
+            ]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [:commit_sexpr, [:nth, [:read_sexpr], 8]]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -96,13 +245,31 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_nthcdr() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :nthcdr, [:xs, :n],
-        [:if, [:==, :n, 0],
-          :xs,
-          [:nthcdr, [:cdr, :xs], [:-, :n, 1]]]],
-      [:function, :scm_main, [],
-        [:commit_sexpr, [:nthcdr, [:read_sexpr], 8]]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :nthcdr,
+            [:xs, :n],
+            [
+              :if,
+              [:==, :n, 0],
+              :xs,
+              [:nthcdr, [:cdr, :xs], [:-, :n, 1]]
+            ]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [:commit_sexpr, [:nthcdr, [:read_sexpr], 8]]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -110,12 +277,27 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_lexical_scoping() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :outer, [:n],
-        [:function, :thunk, [], :n],
-        [[:function, :inner, [:n], [:thunk]], 5]],
-      [:function, :scm_main, [],
-        [:commit_sexpr, [:integer, [:outer, 11]]]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :outer,
+            [:n],
+            [:function, :thunk, [], :n],
+            [[:function, :inner, [:n], [:thunk]], 5]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [:commit_sexpr, [:integer, [:outer, 11]]]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -123,13 +305,43 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_mutual_recursion() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :is_even, [:n],
-        [:if, [:==, :n, 0], true, [:is_odd, [:-, :n, 1]]]],
-      [:function, :is_odd, [:n],
-        [:if, [:==, :n, 0], false, [:is_even, [:-, :n, 1]]]],
-      [:function, :scm_main, [],
-        [:commit_sexpr, [:cons, [:integer, [:is_even, 11]], [:cons, [:integer, [:is_even, 12]], [:integer, [:is_even, 14]]]]]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :is_even,
+            [:n],
+            [:if, [:==, :n, 0], true, [:is_odd, [:-, :n, 1]]]
+          ],
+          [
+            :function,
+            :is_odd,
+            [:n],
+            [:if, [:==, :n, 0], false, [:is_even, [:-, :n, 1]]]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [
+              :commit_sexpr,
+              [
+                :cons,
+                [:integer, [:is_even, 11]],
+                [
+                  :cons,
+                  [:integer, [:is_even, 12]],
+                  [:integer, [:is_even, 14]]
+                ]
+              ]
+            ]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 
@@ -137,13 +349,67 @@ defmodule Examples.ETranspile do
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_nested_mutual_recursion() do
     state = Transpile.new()
-    {state, block} = Transpile.transpile(state,
-      [[:function, :is_odd, [:n],
-        [:function, :is_even, [:n],
-          [:if, [:==, :n, 0], true, [:is_odd, [:-, :n, 1]]]],
-        [:if, [:==, :n, 0], false, [:is_even, [:-, :n, 1]]],],
-      [:function, :scm_main, [],
-        [:commit_sexpr, [:cons, [:integer, [:is_odd, 11]], [:cons, [:integer, [:is_odd, 12]], [:integer, [:is_odd, 14]]]]]]])
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :is_odd,
+            [:n],
+            [
+              :function,
+              :is_even,
+              [:n],
+              [:if, [:==, :n, 0], true, [:is_odd, [:-, :n, 1]]]
+            ],
+            [:if, [:==, :n, 0], false, [:is_even, [:-, :n, 1]]]
+          ],
+          [
+            :function,
+            :scm_main,
+            [],
+            [
+              :commit_sexpr,
+              [
+                :cons,
+                [:integer, [:is_odd, 11]],
+                [
+                  :cons,
+                  [:integer, [:is_odd, 12]],
+                  [:integer, [:is_odd, 14]]
+                ]
+              ]
+            ]
+          ]
+        ]
+      )
+
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_string_literals() do
+    state = Transpile.new()
+
+    {state, block} =
+      Transpile.transpile(
+        state,
+        [
+          [
+            :function,
+            :scm_main,
+            [],
+            [
+              :commit_sexpr,
+              [:panic, "this program is not going to complete"]
+            ]
+          ]
+        ]
+      )
+
     {state, block, Transpile.program_to_string(block)}
   end
 end

--- a/lib/examples/e_transpile.ex
+++ b/lib/examples/e_transpile.ex
@@ -1,0 +1,28 @@
+defmodule Examples.ETranspile do
+  require ExUnit.Assertions
+  import ExUnit.Assertions
+
+  alias Anoma.LocalDomain.Transpile
+
+  def transpile_factorial() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      ["function", "main", [],
+       ["function", "factorial", ["n"],
+        ["if", ["==", "n", 0],
+         1,
+         ["*", "n", ["factorial", ["-", "n", 1]]]]],
+       ["factorial", 5]],
+      {{:literal_expr, 120}, {:type_name, "uintptr_t", {:identifier_declarator, ""}}},
+      [],
+      [])
+    {:expr_stmt,
+     {:binary_expr, binary_op, {:literal_expr, expected_result},
+      {:cast_expr, {:type_name, result_type, _},
+       _}}} = Enum.at(block, -1)
+    assert binary_op == "="
+    assert expected_result == 120
+    assert result_type == "uintptr_t" 
+    {state, block}
+  end
+end

--- a/lib/examples/e_transpile.ex
+++ b/lib/examples/e_transpile.ex
@@ -1,26 +1,35 @@
 defmodule Examples.ETranspile do
   require ExUnit.Assertions
-  import ExUnit.Assertions
 
   alias Anoma.LocalDomain.Transpile
 
   def transpile_factorial() do
     state = Transpile.new()
     {state, block} = Transpile.transpile(state,
-      [:function, :main, [],
+      [[:function, :scm_main, [],
        [:function, :factorial, [:n],
         [:if, [:==, :n, 0],
          1,
          [:*, :n, [:factorial, [:-, :n, 1]]]]],
-       [:factorial, 5]],
-      {{:literal_expr, 120}, {:type_name, "uintptr_t", {:identifier_declarator, ""}}})
-    {:expr_stmt,
-     {:binary_expr, binary_op, {:literal_expr, expected_result},
-      {:cast_expr, {:type_name, result_type, _},
-       _}}} = Enum.at(block, -1)
-    assert binary_op == "="
-    assert expected_result == 120
-    assert result_type == "uintptr_t" 
-    {state, block}
+        [:factorial, 5]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_filter() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :filter, [:xs, :f],
+        [:if, [:is_null, :xs],
+          [:null],
+          [:if, [:f, [:car, :xs]],
+            [:cons, [:car, :xs], [:filter, [:cdr, :xs], :f]],
+            [:filter, [:cdr, :xs], :f]]]],
+      [:function, :scm_main, [],
+        [[:function, :_, [:n],
+          [:commit_sexpr, [:filter, [:read_sexpr],
+            [:function, :divisible_by_n, [:x], [:==, [:%, [:as_integer, :x], :n], 0]]]]], 3]]])
+    {state, block, Transpile.program_to_string(block)}
   end
 end

--- a/lib/examples/e_transpile.ex
+++ b/lib/examples/e_transpile.ex
@@ -7,12 +7,12 @@ defmodule Examples.ETranspile do
   def transpile_factorial() do
     state = Transpile.new()
     {state, block} = Transpile.transpile(state,
-      ["function", "main", [],
-       ["function", "factorial", ["n"],
-        ["if", ["==", "n", 0],
+      [:function, :main, [],
+       [:function, :factorial, [:n],
+        [:if, [:==, :n, 0],
          1,
-         ["*", "n", ["factorial", ["-", "n", 1]]]]],
-       ["factorial", 5]],
+         [:*, :n, [:factorial, [:-, :n, 1]]]]],
+       [:factorial, 5]],
       {{:literal_expr, 120}, {:type_name, "uintptr_t", {:identifier_declarator, ""}}},
       [],
       [])

--- a/lib/examples/e_transpile.ex
+++ b/lib/examples/e_transpile.ex
@@ -13,9 +13,7 @@ defmodule Examples.ETranspile do
          1,
          [:*, :n, [:factorial, [:-, :n, 1]]]]],
        [:factorial, 5]],
-      {{:literal_expr, 120}, {:type_name, "uintptr_t", {:identifier_declarator, ""}}},
-      [],
-      [])
+      {{:literal_expr, 120}, {:type_name, "uintptr_t", {:identifier_declarator, ""}}})
     {:expr_stmt,
      {:binary_expr, binary_op, {:literal_expr, expected_result},
       {:cast_expr, {:type_name, result_type, _},

--- a/lib/examples/e_transpile.ex
+++ b/lib/examples/e_transpile.ex
@@ -389,7 +389,7 @@ defmodule Examples.ETranspile do
     {state, block, Transpile.program_to_string(block)}
   end
 
-  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let input = Resource { data: Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>()), quantity: 0 };
   # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_string_literals() do
     state = Transpile.new()
@@ -433,12 +433,27 @@ defmodule Examples.ETranspile do
     {state, block, Transpile.program_to_string(block)}
   end
 
+  # let input = Resource { data: Sexpr::from(3), quantity: 1 };
+  # let output: Sexpr = receipt.journal.decode().unwrap();
   def transpile_integer_logic() do
     state = Transpile.new()
     {state, block} = Transpile.transpile(state,
       [
-        
+        [
+          :function,
+          :integer_resource_logic,
+          [:obj],
+          [:is_integer, [:get, :obj, "data"]]
+        ],
+        [
+          :function,
+          :scm_main,
+          [],
+          [:commit_sexpr, [:boolean, [:integer_resource_logic, [:read_resource]]]]
+        ]
       ])
+
+    {state, block, Transpile.program_to_string(block)}
     
   end
 end

--- a/lib/examples/e_transpile.ex
+++ b/lib/examples/e_transpile.ex
@@ -32,4 +32,118 @@ defmodule Examples.ETranspile do
             [:function, :divisible_by_n, [:x], [:==, [:%, [:as_integer, :x], :n], 0]]]]], 3]]])
     {state, block, Transpile.program_to_string(block)}
   end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_take() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :take, [:xs, :n],
+        [:if, [:==, :n, 0],
+          [:null],
+          [:cons, [:car, :xs], [:take, [:cdr, :xs], [:-, :n, 1]]]]],
+      [:function, :scm_main, [],
+        [[:function, :_, [:n],
+          [:commit_sexpr, [:take, [:read_sexpr], :n]]], 3]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_map() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :map, [:xs, :f],
+        [:if, [:is_null, :xs],
+          [:null],
+          [:cons, [:f, [:car, :xs]], [:map, [:cdr, :xs], :f]]]],
+      [:function, :scm_main, [],
+        [[:function, :_, [:n],
+          [:commit_sexpr, [:map, [:read_sexpr],
+            [:function, :multiply_by_n, [:x], [:integer, [:*, [:as_integer, :x], :n]]]]]], 4]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_length() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :length, [:xs],
+        [:if, [:is_null, :xs],
+          0,
+          [:+, 1, [:length, [:cdr, :xs]]]]],
+      [:function, :scm_main, [],
+        [:commit_sexpr, [:integer, [:length, [:read_sexpr]]]]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_nth() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :nth, [:xs, :n],
+        [:if, [:==, :n, 0],
+          [:car, :xs],
+          [:nth, [:cdr, :xs], [:-, :n, 1]]]],
+      [:function, :scm_main, [],
+        [:commit_sexpr, [:nth, [:read_sexpr], 8]]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_nthcdr() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :nthcdr, [:xs, :n],
+        [:if, [:==, :n, 0],
+          :xs,
+          [:nthcdr, [:cdr, :xs], [:-, :n, 1]]]],
+      [:function, :scm_main, [],
+        [:commit_sexpr, [:nthcdr, [:read_sexpr], 8]]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_lexical_scoping() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :outer, [:n],
+        [:function, :thunk, [], :n],
+        [[:function, :inner, [:n], [:thunk]], 5]],
+      [:function, :scm_main, [],
+        [:commit_sexpr, [:integer, [:outer, 11]]]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_mutual_recursion() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :is_even, [:n],
+        [:if, [:==, :n, 0], true, [:is_odd, [:-, :n, 1]]]],
+      [:function, :is_odd, [:n],
+        [:if, [:==, :n, 0], false, [:is_even, [:-, :n, 1]]]],
+      [:function, :scm_main, [],
+        [:commit_sexpr, [:cons, [:integer, [:is_even, 11]], [:cons, [:integer, [:is_even, 12]], [:integer, [:is_even, 14]]]]]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
+
+  # let input = Sexpr::from((0..100).map(|x| Sexpr::from(2 * x + 1)).collect::<Vec::<_>>());
+  # let output: Sexpr = receipt.journal.decode().unwrap();
+  def transpile_nested_mutual_recursion() do
+    state = Transpile.new()
+    {state, block} = Transpile.transpile(state,
+      [[:function, :is_odd, [:n],
+        [:function, :is_even, [:n],
+          [:if, [:==, :n, 0], true, [:is_odd, [:-, :n, 1]]]],
+        [:if, [:==, :n, 0], false, [:is_even, [:-, :n, 1]]],],
+      [:function, :scm_main, [],
+        [:commit_sexpr, [:cons, [:integer, [:is_odd, 11]], [:cons, [:integer, [:is_odd, 12]], [:integer, [:is_odd, 14]]]]]]])
+    {state, block, Transpile.program_to_string(block)}
+  end
 end

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -72,51 +72,75 @@ defmodule Anoma.LocalDomain.Scheme do
     end), prelude_fns}
   end
 
-  def new_env(), do: {%{}, 0, 1}
-
+  def new_env(), do: {%{}, 0, 1, 0}
 
   @doc """
   Put a given binding into the environment
   """
-  def put_env({tree, index, next}, name, value) do
-    {Map.put(tree, next, {name, value, index}), next, next+1}
+  def put_env({tree, index, next, frame}, name, value) do
+    {Map.put(tree, next, {name, value, index, frame}), next, next+1, frame}
   end
 
   @doc """
   Get the value of the given identifier in the environment
   """
-  def get_env({tree, index, next}, search_name) do
+  def get_env({tree, index, next, frame}, search_name) do
     case Map.fetch(tree, index) do
-      {:ok, {^search_name, value, _parent}} -> value
-      {:ok, {_name, _value, parent}} -> get_env({tree, parent, next}, search_name)
+      {:ok, {^search_name, value, _parent, _frame}} -> value
+      {:ok, {_name, _value, parent, _frame}} -> get_env({tree, parent, next, frame}, search_name)
       :error -> raise "#{search_name} not in scope"
+    end
+  end
+
+  @doc """
+  Switch to the given stack frame
+  """
+  def switch_env_frame({tree, index, next, frame}, target) do
+    case Map.fetch(tree, index) do
+      {:ok, {_name, _value, _parent, ^target}} -> {tree, index, next, frame}
+      {:ok, {_name, _value, parent, _frame}} -> switch_env_frame({tree, parent, next, frame}, target)
+      :error -> raise "frame #{target} not in scope"
     end
   end
 
   @doc """
   Get the unique identifier for the given environment
   """
-  def env_id({_tree, index, _next}), do: index
+  def env_id({_tree, index, _next, _frame}), do: index
 
   @doc """
   Reserve a unique environment identifier to fill in later
   """
-  def reserve_env({tree, index, next}) do
-    {{tree, index, next+1}, next}
+  def reserve_env({tree, index, next, frame}) do
+    {{tree, index, next+1, frame}, next}
   end
 
   @doc """
   Insert the given binding at the given unique identifier
   """
-  def insert_env({tree, index, next}, at, name, value) do
-    {Map.put(tree, at, {name, value, index}), at, next}
+  def insert_env({tree, index, next, frame}, at, name, value) do
+    {Map.put(tree, at, {name, value, index, frame}), at, next, frame}
   end
 
   @doc """
   Switch to the given environment
   """
-  def switch_env({tree, _index, next}, target) do
-    {tree, target, next}
+  def switch_env({tree, _index, next, frame}, target) do
+    {tree, target, next, frame}
+  end
+
+  @doc """
+  Push new stack frame onto the environment
+  """
+  def push_env_frame({tree, index, next, frame}) do
+    {tree, index, next, frame+1}
+  end
+
+  @doc """
+  Pop stack frame from the environment
+  """
+  def pop_env_frame({tree, index, next, frame}) do
+    {tree, index, next, frame-1}
   end
 
   @doc """
@@ -185,7 +209,14 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def eval(expr = [:expand | _], env) do
-    eval(elem(expand_macros(expr, env), 0), env)
+    # Save the environment just before macro expansion
+    expansion_env_id = env_id(env)
+    # Macro expansion cannot access locals - switch to global environment
+    macro_env = switch_env_frame(env, 0)
+    # Expand the macro in the global environment
+    {expansion, macro_env} = expand_macros(expr, macro_env)
+    # Finally evaluate the expanded macro in original environment
+    eval(expansion, switch_env(macro_env, expansion_env_id))
   end
 
   # Define evaluate by reducing to simpler expressions
@@ -217,6 +248,7 @@ defmodule Anoma.LocalDomain.Scheme do
     caller_env_id = env_id(env)
     # Move to the closure/callee's environment
     callee_env = switch_env(env, closure_env_id)
+    callee_env = push_env_frame(callee_env)
     # Bind the closure's parameters
     put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
     callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
@@ -226,6 +258,7 @@ defmodule Anoma.LocalDomain.Scheme do
     eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
     {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
     # Move back to the caller's environment
+    env = pop_env_frame(env)
     {result, switch_env(env, caller_env_id)}
   end
 
@@ -234,11 +267,6 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   # Recursively expand macros
-
-  def expand_macros({:closure, params, body, closure_env_id}, env) do
-    {body, env} = expand_macros(body, env)
-    {{:closure, params, body, closure_env_id}, env}
-  end
 
   def expand_macros(expr = [:expand, reference | _], env) do
     # Evaluate the reference expression - this should result in a function

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -86,11 +86,10 @@ defmodule Anoma.LocalDomain.Scheme do
   Get the value of the given identifier in the environment
   """
   def get_env({tree, index, next}, search_name) do
-    {name, value, parent} = Map.fetch!(tree, index)
-    if name == search_name do
-      value
-    else
-      get_env({tree, parent, next}, search_name)
+    case Map.fetch(tree, index) do
+      {:ok, {^search_name, value, _parent}} -> value
+      {:ok, {_name, _value, parent}} -> get_env({tree, parent, next}, search_name)
+      :error -> raise "#{search_name} not in scope"
     end
   end
 
@@ -146,9 +145,9 @@ defmodule Anoma.LocalDomain.Scheme do
 
   # Guards to recognize special values in the DSL
 
-  defguard is_closure(obj) when is_tuple(obj) and length(obj) == 4 and elem(obj, 0) == :closure
+  defguard is_closure(obj) when is_tuple(obj) and tuple_size(obj) == 4 and elem(obj, 0) == :closure
 
-  defguard is_native(obj) when is_tuple(obj) and length(obj) == 3 and elem(obj, 0) == :native
+  defguard is_native(obj) when is_tuple(obj) and tuple_size(obj) == 3 and elem(obj, 0) == :native
 
   # Evaluate the given expression in the given environment
 
@@ -183,6 +182,10 @@ defmodule Anoma.LocalDomain.Scheme do
     closure = {:closure, params, body, closure_env_id}
     env = insert_env(env, closure_env_id, name, closure)
     {closure, env}
+  end
+
+  def eval(expr = [:expand | _], env) do
+    eval(elem(expand_macros(expr, env), 0), env)
   end
 
   # Define evaluate by reducing to simpler expressions
@@ -238,12 +241,8 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def expand_macros(expr = [:expand, reference | _], env) do
-    # Expand the macros in the reference expression
-    {reference, env} = expand_macros(reference, env)
     # Evaluate the reference expression - this should result in a function
     {reference, env} = eval(reference, env)
-    # Expand the macros used in the value of the reference expression
-    {reference, env} = expand_macros(reference, env)
     # Apply the reference expression to representation of this expression
     {expansion, env} = eval_apply(reference, [expr], env)
     # Finally, attempt to expand the output of the macro

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -137,33 +137,15 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def build_body_env(_, acc), do: acc
-  
-  def eval(num, env) when is_number(num) do
-    {num, env}
-  end
 
-  def eval(true, env) do
-    {true, env}
-  end
+  # Evaluate the given expression in the given environment
 
-  def eval(false, env) do
-    {false, env}
-  end
-
-  def eval(nil, env) do
-    {nil, env}
-  end
-
-  def eval(str, env) when is_binary(str) do
-    {str, env}
+  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_function(obj) do
+    {obj, env}
   end
 
   def eval(var, env) when is_atom(var) do
     {get_env(env, var), env}
-  end
-
-  def eval(func, env) when is_function(func) do
-    {func, env}
   end
 
   def eval(map, env) when is_map(map) do

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -170,16 +170,6 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
-  def eval([:and, expr1, expr2], env) do
-    eval([:if, expr1, expr2, false], env)
-  end
-
-  def eval([:or, expr1, expr2], env) do
-    eval([:if, expr1, true, expr2], env)
-  end
-
-  def eval([:list | args], env), do: Enum.map_reduce(args, env, &eval/2)
-
   def eval([:quote, expr], env), do: {expr, env}
 
   def eval([:function, name, params | body], env) do
@@ -189,11 +179,34 @@ defmodule Anoma.LocalDomain.Scheme do
     {closure, env}
   end
 
+  # Define evaluate by reducing to simpler expressions
+
+  def eval([:and, expr1, expr2], env) do
+    eval([:if, expr1, expr2, false], env)
+  end
+
+  def eval([:or, expr1, expr2], env) do
+    eval([:if, expr1, true, expr2], env)
+  end
+
+  def eval([:list | args], env) do
+    expansion = Enum.reduce(Enum.reverse(args), :null, fn elt, acc -> [:cons, elt, acc] end)
+    eval(expansion, env)
+  end
+
   def eval([:apply, op, args], env) do
     {args, env} = eval(args, env)
     {op, env} = eval(op, env)
     eval_apply(op, args, env)
   end
+
+  def eval([op | args], env) do
+    {args, env} = Enum.map_reduce(args, env, &eval/2)
+    {op, env} = eval(op, env)
+    eval_apply(op, args, env)
+  end
+
+  # Apply the given arguments to the given function
 
   def eval_apply({:closure, params, body, closure_env_id}, args, env) do
     caller_env_id = env_id(env)
@@ -211,8 +224,6 @@ defmodule Anoma.LocalDomain.Scheme do
   def eval_apply({:native, module, functor}, args, env) do
     {apply(module, functor, args), env}
   end
-
-  def eval([op | args], env), do: eval([:apply, op, [:list | args]], env)
 
   # Evaluate the given expression with a prelude prepended
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -198,34 +198,6 @@ defmodule Anoma.LocalDomain.Scheme do
 
       :list -> Enum.map_reduce(args, env, &eval/2)
 
-      :car ->
-        case eval(hd(args), env) do
-          {args, env} -> {hd(args), env}
-          _ -> :err
-        end
-
-      :cdr ->
-        case eval(hd(args), env) do
-          {args, env} ->
-            if length(args) == 1 do
-              {nil, env}
-            else
-              {tl(args), env}
-            end
-
-          _ ->
-            :cdr_err
-        end
-
-      :cons ->
-        {car, env} = eval(hd(args), env)
-
-        case eval(Enum.at(args, 1), env) do
-          {nil, env} -> {[car], env}
-          {args, env} -> {[car | args], env}
-          _ -> :err
-        end
-
       :and ->
         case eval(hd(args), env) do
           {true, env} -> eval(Enum.at(args, 1), env)

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -172,8 +172,6 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
-  def eval([:quote, expr], env), do: {expr, env}
-
   def eval([:function, name, params | body], env) do
     {env, closure_env_id} = reserve_env(env)
     closure = {:closure, params, body, closure_env_id}

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -118,9 +118,6 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def eval([op | args], env, store) do
-    # IO.inspect(op)
-    # IO.inspect(args)
-    # IO.inspect(env)
     case op do
       :if ->
         {cond_statement, _, _} = eval(hd(args), env, store)
@@ -187,6 +184,27 @@ defmodule Anoma.LocalDomain.Scheme do
         {val, _, _} = eval(val, env, store)
         eval(body, Map.put(env, name, val), store)
 
+      :labels ->
+        IO.puts(op)
+        [labels, body] = args
+        cells = Enum.map(labels,
+          fn [name, params, label_body] ->
+            id = Base.encode16(:crypto.strong_rand_bytes(8))
+            {name, params, label_body, id}
+          end)
+
+        closure_env = Enum.reduce(cells, env,
+          fn {name, _params, _label_body, id}, acc ->
+            Map.put(acc, name, {:cell, id})
+          end)
+
+        new_store = Enum.reduce(cells, store,
+          fn {_name, params, body, id}, acc ->
+            Map.put(acc, id, {:closure, params, body, closure_env})
+          end)
+
+        eval(body, closure_env, new_store)
+        
       :do ->
         Enum.reduce(args, {nil, env, store},
           fn arg, {_, acc, store} ->

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -9,7 +9,7 @@ defmodule Anoma.LocalDomain.Scheme do
         accumulate: true
       )
 
-      Module.register_attribute(__MODULE__, :risc0_template,
+      Module.register_attribute(__MODULE__, :elixir_fns,
         accumulate: true
       )
 
@@ -21,15 +21,15 @@ defmodule Anoma.LocalDomain.Scheme do
   defmacro __before_compile__(env) do
     module = env.module
     scheme_fns = Module.get_attribute(module, :scheme_fns)
-    risc0_template = Module.get_attribute(module, :risc0_template)
+    elixir_fns = Module.get_attribute(module, :elixir_fns)
 
     quote do
       def __scheme_fns__ do
         unquote(Macro.escape(scheme_fns))
       end
 
-      def __risc0_template__ do
-        unquote(Macro.escape(risc0_template))
+      def __elixir_fns__ do
+        unquote(Macro.escape(elixir_fns))
       end
 
       # This doesn't work first compilation, only recompilation
@@ -44,51 +44,26 @@ defmodule Anoma.LocalDomain.Scheme do
   Define an elixir->scheme mapping
   """
   defmacro defrisc({name, _meta, args},
-             do: [{:->, _, [[body_elixir], scheme_template]}]
+             do: body_elixir
            ) do
-    ["list" | args_scheme] = ast_to_scheme(args)
+    [:list | args_scheme] = ast_to_scheme(args)
 
     quote do
       def unquote(name)(unquote_splicing(args)) do
         unquote(body_elixir)
       end
 
-      @risc0_template {unquote(name), unquote(args_scheme),
-                       unquote(Macro.escape(body_elixir)),
-                       unquote(scheme_template)}
+      @elixir_fns {unquote(name), unquote(args_scheme),
+                   unquote(Macro.escape(body_elixir))}
     end
   end
 
-  defmacro defrisc({name, _meta, args}, do: body_elixir) do
-    ["list" | args_scheme] = ast_to_scheme(args)
+  defmacro defscheme({name_scheme, _meta, args}, do: body_scheme) do
+    [:list | args_scheme] = ast_to_scheme(args)
 
     quote do
-      def unquote(name)(unquote_splicing(args)) do
-        unquote(body_elixir)
-      end
-
-      @risc0_template {unquote(name), unquote(args_scheme),
-                       unquote(Macro.escape(body_elixir)), nil}
-    end
-  end
-
-  defmacro defscheme({name_scheme, _meta, args},
-             do: body_scheme
-           ) do
-    ["list" | args_scheme] = ast_to_scheme(args)
-
-    quote do
-      @scheme_fns {unquote(Atom.to_string(name_scheme)),
-                   unquote(args_scheme), unquote(body_scheme)}
-    end
-  end
-
-  defmacro defscheme({name_scheme, _meta, args}, name) do
-    ["list" | args_scheme] = ast_to_scheme(args)
-
-    quote do
-      @scheme_fns {unquote(Atom.to_string(name_scheme)),
-                   unquote(args_scheme), unquote(name)}
+      @scheme_fns {unquote(name_scheme), unquote(args_scheme),
+                   unquote(body_scheme)}
     end
   end
 
@@ -105,18 +80,6 @@ defmodule Anoma.LocalDomain.Scheme do
     num
   end
 
-  def eval(var, env) when is_binary(var) do
-    Map.fetch!(env, var)
-  end
-
-  def eval(atom, _env) when is_atom(atom) do
-    atom
-  end
-
-  def eval(func, _env) when is_function(func) do
-    func
-  end
-
   def eval(true, _env) do
     true
   end
@@ -129,85 +92,97 @@ defmodule Anoma.LocalDomain.Scheme do
     nil
   end
 
+  def eval(str, _env) when is_binary(str) do
+    str
+  end
+
+  def eval(var, env) when is_atom(var) do
+    Map.fetch!(env, var)
+  end
+
+  def eval(func, _env) when is_function(func) do
+    func
+  end
+
   def eval(map, env) when is_map(map) do
     map
     |> Enum.map(fn {k, v} -> {eval(k, env), eval(v, env)} end)
     |> Map.new()
   end
 
-  def eval({"closure", params, body}, _env) do
-    {"closure", params, body}
+  def eval({:closure, params, body}, _env) do
+    {:closure, params, body}
   end
 
-  def eval({"native", module, functor}, _env) do
-    {"native", module, functor}
+  def eval({:native, module, functor}, _env) do
+    {:native, module, functor}
   end
 
   def eval([op | args], env) do
     case op do
-      "if" ->
+      :if ->
         if eval(hd(args), env) do
           eval(Enum.at(args, 1), env)
         else
           eval(Enum.at(args, 2), env)
         end
 
-      "quote" ->
+      :quote ->
         hd(args)
 
-      "list" ->
-        ["list" | Enum.map(args, fn arg -> eval(arg, env) end)]
+      :list ->
+        [:list | Enum.map(args, fn arg -> eval(arg, env) end)]
 
-      "car" ->
+      :car ->
         case eval(hd(args), env) do
-          ["list" | args] -> hd(args)
+          [:list | args] -> hd(args)
           _ -> :err
         end
 
-      "cdr" ->
+      :cdr ->
         case eval(hd(args), env) do
-          ["list" | args] ->
+          [:list | args] ->
             if length(args) == 1 do
               nil
             else
-              ["list" | tl(args)]
+              [:list | tl(args)]
             end
 
           _ ->
             :err
         end
 
-      "cons" ->
+      :cons ->
         car = eval(hd(args), env)
 
         case eval(Enum.at(args, 1), env) do
-          ["list" | args] -> ["list", car | args]
-          nil -> ["list", car]
+          [:list | args] -> [:list, car | args]
+          nil -> [:list, car]
           _ -> :err
         end
 
-      "and" ->
+      :and ->
         case eval(hd(args), env) do
           true -> eval(Enum.at(args, 1), env)
           false -> false
         end
 
-      "or" ->
+      :or ->
         case eval(hd(args), env) do
           true -> true
           false -> eval(Enum.at(args, 1), env)
         end
 
-      "lambda" ->
-        {"closure", hd(args), Enum.at(args, 1)}
+      :lambda ->
+        {:closure, hd(args), Enum.at(args, 1)}
 
-      "apply" ->
+      :apply ->
         [op, args] = args
 
         args = eval(args, env)
 
         case eval(op, env) do
-          {"closure", params, body} ->
+          {:closure, params, body} ->
             env =
               Enum.reduce(Enum.zip(params, tl(args)), env, fn {param,
                                                                arg},
@@ -215,9 +190,10 @@ defmodule Anoma.LocalDomain.Scheme do
                 Map.put(acc, param, arg)
               end)
 
+            # require IEx; IEx.pry
             eval(body, env)
 
-          {"native", module, functor} ->
+          {:native, module, functor} ->
             apply(module, functor, tl(args))
 
           _ ->
@@ -225,7 +201,7 @@ defmodule Anoma.LocalDomain.Scheme do
         end
 
       _ ->
-        eval(["apply", op, ["list" | args]], env)
+        eval([:apply, op, [:list | args]], env)
     end
   end
 
@@ -233,29 +209,28 @@ defmodule Anoma.LocalDomain.Scheme do
     eval(expr, default_env())
   end
 
-  def elixir_fn_to_scheme(mod, name) do
-    case Anoma.LocalDomain.SchemeRegistry.get_template(mod, name) do
-      :absent ->
-        {:ok, args, ast} =
-          Anoma.LocalDomain.SchemeRegistry.get_ast(mod, name)
-
-        ast_to_scheme(args, ast)
-
-      {:ok, template} ->
-        template
-    end
-  end
-
   def ast_to_scheme(args, ast) do
-    {"closure", args, ast_to_scheme(ast)}
+    {:closure, args, ast_to_scheme(ast)}
   end
 
   def ast_to_scheme(n) when is_integer(n) do
     n
   end
 
+  def ast_to_scheme(true) do
+    true
+  end
+
+  def ast_to_scheme(false) do
+    false
+  end
+
+  def ast_to_scheme(nil) do
+    nil
+  end
+
   def ast_to_scheme(k) when is_atom(k) do
-    k
+    Atom.to_string(k)
   end
 
   def ast_to_scheme(b) when is_boolean(b) do
@@ -263,14 +238,14 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def ast_to_scheme(xs) when is_list(xs) do
-    ["list" | Enum.map(xs, fn x -> ast_to_scheme(x) end)]
+    [:list | Enum.map(xs, fn x -> ast_to_scheme(x) end)]
   end
 
   def ast_to_scheme(
         {:if, _, [condition, [do: if_branch, else: else_branch]]}
       ) do
     [
-      "if",
+      :if,
       ast_to_scheme(condition),
       ast_to_scheme(if_branch),
       ast_to_scheme(else_branch)
@@ -279,7 +254,7 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def ast_to_scheme({:fn, _, [{:->, _, [inputs, body]}]}) do
     [
-      "lambda",
+      :lambda,
       Enum.map(inputs, fn i -> ast_to_scheme(i) end),
       ast_to_scheme(body)
     ]
@@ -299,32 +274,31 @@ defmodule Anoma.LocalDomain.Scheme do
         {ast_to_scheme(k), ast_to_scheme(v)}
       end)
 
-    ast_to_scheme({:%{}, [], kvs ++ [__struct__: mod]})
+    ast_to_scheme({:%{}, [], kvs ++ [{"__struct__", mod}]})
   end
 
   def ast_to_scheme({:__aliases__, _, mod}) do
-    Module.concat(mod)
+    Atom.to_string(Module.concat(mod))
   end
 
   def ast_to_scheme({:., _, [mod, fn_name]}) do
     # Module namespaced function
-    mod = ast_to_scheme(mod)
+    _mod = ast_to_scheme(mod)
 
-    elixir_fn_to_scheme(mod, fn_name)
+    fn_name
   end
 
   def ast_to_scheme({fn_name, _, args}) when is_list(args) do
     # Function Application
-    [
-      ast_to_scheme(fn_name)
-      | Enum.map(args, fn x -> ast_to_scheme(x) end)
-    ]
+    func = ast_to_scheme(fn_name)
+    args = Enum.map(args, fn x -> ast_to_scheme(x) end)
+
+    [func | args]
   end
 
   def ast_to_scheme({:erlang, _, _}), do: :erlang
 
   def ast_to_scheme({sym, _, _mod}) do
-    # Syms are currently strings
-    Atom.to_string(sym)
+    sym
   end
 end

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -132,11 +132,17 @@ defmodule Anoma.LocalDomain.Scheme do
   @doc """
   Add functions to the environment
   """
-  def build_body_env([:function, name, params | body], {env, body_env_id}) do
+  def bind_function([:function, name, params | body], {env, body_env_id}) do
     {put_env(env, name, {:closure, params, body, body_env_id}), body_env_id}
   end
 
-  def build_body_env(_, acc), do: acc
+  def bind_function(_, acc), do: acc
+
+  def build_body_env(body, callee_env) do
+    {callee_env, body_env_id} = reserve_env(callee_env)
+    {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &bind_function/2)
+    insert_env(callee_env, body_env_id, nil, nil)
+  end
 
   # Guards to recognize special values in the DSL
 
@@ -212,9 +218,7 @@ defmodule Anoma.LocalDomain.Scheme do
     put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
     callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
     # Bind mutually recursive functions in the body
-    {callee_env, body_env_id} = reserve_env(callee_env)
-    {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
-    callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    callee_env = build_body_env(body, callee_env)
     # Evaluate the body expressions
     eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
     {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
@@ -226,14 +230,44 @@ defmodule Anoma.LocalDomain.Scheme do
     {apply(module, functor, args), env}
   end
 
+  # Recursively expand macros
+
+  def expand_macros(expr = [:expand, reference | _], env) do
+    {reference, env} = eval(reference, env)
+    {expansion, env} = eval_apply(reference, [expr], env)
+    expand_macros(expansion, env)
+  end
+
+  def expand_macros(expr, env) when is_list(expr) do
+    Enum.map_reduce(expr, env, &expand_macros/2)
+  end
+
+  def expand_macros(expr, env), do: {expr, env}
+
+  # Recursively expand tuples to lists
+
+  def expand_tuples(expr) when is_tuple(expr) do
+    expand_tuples([:expand | Tuple.to_list(expr)])
+  end
+
+  def expand_tuples(expr) when is_list(expr) do
+    Enum.map(expr, &expand_tuples/1)
+  end
+
+  def expand_tuples(expr), do: expr
+
   # Evaluate the given expression with a prelude prepended
 
   @doc """
   Evaluate the given expression with a prelude prepended
   """
-  def eval(expr) do
+  def eval(exprs) do
     {env, prelude} = default_env()
-    eval([[:function, :_, [] | prelude] ++ [expr]], env)
+    exprs = prelude ++ exprs
+    exprs = Enum.map(exprs, &expand_tuples/1)
+    funcs = build_body_env(exprs, env)
+    {exprs, _} = Enum.map_reduce(exprs, funcs, &expand_macros/2)
+    eval([[:function, :_, [] | exprs]], env)
   end
 
   @doc """

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -290,10 +290,13 @@ defmodule Anoma.LocalDomain.Scheme do
   """
   def eval(expr) do
     {env, prelude} = default_env()
-    IO.inspect(prelude)
+    # IO.inspect([[:function, :_, [] | prelude] ++ [expr]])
     eval([[:function, :_, [] | prelude] ++ [expr]], env)
   end
 
+  @doc """
+  Turn an Elixir AST to Scheme
+  """
   def ast_to_scheme(n) when is_integer(n) do
     n
   end

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -64,10 +64,9 @@ defmodule Anoma.LocalDomain.Scheme do
   def default_env(extra \\ %{}) do
     {:ok, scheme_fns} = Anoma.LocalDomain.SchemeRegistry.all_scheme()
 
-    map_to_env(Map.merge(
-      scheme_fns,
-      extra
-    ))
+    Enum.reduce(extra, scheme_fns, fn {name, value}, acc ->
+      put_env(acc, name, value)
+    end)
   end
 
   def new_env(), do: {%{}, 0, 1}
@@ -105,6 +104,12 @@ defmodule Anoma.LocalDomain.Scheme do
     {Map.put(tree, at, {name, value, index}), at, next}
   end
 
+  # Switch to the given environment
+
+  def switch_env({tree, index, next}, target) do
+    {tree, target, next}
+  end
+
   # Convert an ordinary Elixir map into an environment
 
   def map_to_env(map) do
@@ -113,76 +118,81 @@ defmodule Anoma.LocalDomain.Scheme do
     end)
   end
 
-  def eval(num, _env) when is_number(num) do
-    num
+  def eval(num, env) when is_number(num) do
+    {num, env}
   end
 
-  def eval(true, _env) do
-    true
+  def eval(true, env) do
+    {true, env}
   end
 
-  def eval(false, _env) do
-    false
+  def eval(false, env) do
+    {false, env}
   end
 
-  def eval(nil, _env) do
-    nil
+  def eval(nil, env) do
+    {nil, env}
   end
 
-  def eval(str, _env) when is_binary(str) do
-    str
+  def eval(str, env) when is_binary(str) do
+    {str, env}
   end
 
   def eval(var, env) when is_atom(var) do
-    get_env(env, var)
+    {get_env(env, var), env}
   end
 
-  def eval(func, _env) when is_function(func) do
-    func
+  def eval(func, env) when is_function(func) do
+    {func, env}
   end
 
   def eval(map, env) when is_map(map) do
-    map
-    |> Enum.map(fn {k, v} -> {eval(k, env), eval(v, env)} end)
-    |> Map.new()
+    {map, env} = map
+    |> Enum.map_reduce(env, fn {k, v}, env ->
+      {k, env} = eval(k, env)
+      {v, env} = eval(v, env)
+      {{k, v}, env} end)
+    {Map.new(map), env}
   end
 
-  def eval({:closure, params, body}, _env) do
-    {:closure, params, body}
+  def eval({:closure, params, body, closure_env_id}, env) do
+    {{:closure, params, body, closure_env_id}, env}
   end
 
-  def eval({:native, module, functor}, _env) do
-    {:native, module, functor}
+  def eval({:native, module, functor}, env) do
+    {{:native, module, functor}, env}
   end
 
   def eval([op | args], env) do
     case op do
       :if ->
-        if eval(hd(args), env) do
+        {cond, env} = eval(hd(args), env)
+        if cond do
           eval(Enum.at(args, 1), env)
         else
           eval(Enum.at(args, 2), env)
         end
 
       :quote ->
-        hd(args)
+        {hd(args), env}
 
       :list ->
-        [:list | Enum.map(args, fn arg -> eval(arg, env) end)]
+        {list, env} = Enum.map_reduce(args, env, fn arg, env -> eval(arg, env) end)
+        {[:list | list], env}
 
       :car ->
         case eval(hd(args), env) do
-          [:list | args] -> hd(args)
+          {[:list | args], env} -> {hd(args), env}
           _ -> :err
         end
 
       :cdr ->
         case eval(hd(args), env) do
-          [:list | args] ->
+          {[:list | args], env} ->
             if length(args) == 1 do
-              nil
+              {nil, env}
             else
-              [:list | tl(args)]
+              {[:list | tl(args)], env}
             end
 
           _ ->
@@ -190,56 +200,59 @@ defmodule Anoma.LocalDomain.Scheme do
         end
 
       :cons ->
-        car = eval(hd(args), env)
+        {car, env} = eval(hd(args), env)
 
         case eval(Enum.at(args, 1), env) do
-          [:list | args] -> [:list, car | args]
-          nil -> [:list, car]
+          {[:list | args], env} -> {[:list, car | args], env}
+          {nil, env} -> {[:list, car], env}
           _ -> :err
         end
 
       :and ->
         case eval(hd(args), env) do
-          true -> eval(Enum.at(args, 1), env)
-          false -> false
+          {true, env} -> eval(Enum.at(args, 1), env)
+          {false, env} -> {false, env}
         end
 
       :or ->
         case eval(hd(args), env) do
-          true -> true
-          false -> eval(Enum.at(args, 1), env)
+          {env, true} -> {true, env}
+          {false, env} -> eval(Enum.at(args, 1), env)
         end
 
       :lambda ->
-        {:closure, hd(args), Enum.at(args, 1), env}
+        {{:closure, hd(args), Enum.at(args, 1), env_id(env)}, env}
 
       :apply ->
         [op, args] = args
 
-        args = eval(args, env)
+        {args, env} = eval(args, env)
 
         case eval(op, env) do
-          {:closure, params, body, closure_env} ->
+          {{:closure, params, body, closure_env_id}, env} ->
+            caller_env_id = env_id(env)
             call_env =
               Enum.reduce(
                 Enum.zip(params, tl(args)),
-                closure_env,
+                switch_env(env, closure_env_id),
                 fn {param, arg}, acc ->
                   put_env(acc, param, arg)
                 end
               )
 
-            eval(
+            {result, env} = eval(
               body,
               put_env(
                 call_env,
                 :self,
-                {:closure, params, body, closure_env}
+                {:closure, params, body, closure_env_id}
               )
-            )
+                            )
 
-          {:native, module, functor} ->
-            apply(module, functor, tl(args))
+            {result, switch_env(env, caller_env_id)}
+
+          {{:native, module, functor}, env} ->
+            {apply(module, functor, tl(args)), env}
 
           _ ->
             :err

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -61,122 +61,156 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
-  def default_env(extra \\ %{}) do
-    {:ok, scheme_fns} = Anoma.LocalDomain.SchemeRegistry.all_scheme()
+  def default_env() do
+    {:ok, scheme_fns, store} = Anoma.LocalDomain.SchemeRegistry.all_scheme()
 
-    Map.merge(
-      scheme_fns,
-      extra
-    )
+    {scheme_fns, store}
   end
 
-  def eval(num, _env) when is_number(num) do
-    num
+  def eval(num, env, store) when is_number(num) do
+    {num, env, store}
   end
 
-  def eval(true, _env) do
-    true
+  def eval(true, env, store) do
+    {true, env, store}
   end
 
-  def eval(false, _env) do
-    false
+  def eval(false, env, store) do
+    {false, env, store}
   end
 
-  def eval(nil, _env) do
-    nil
+  def eval(nil, env, store) do
+    {nil, env, store}
   end
 
-  def eval(str, _env) when is_binary(str) do
-    str
+  def eval(str, env, store) when is_binary(str) do
+    {str, env, store}
   end
 
-  def eval(var, env) when is_atom(var) do
-    Map.fetch!(env, var)
+  def eval(var, env, store) when is_atom(var) do
+    {Map.fetch!(env, var), env, store}
   end
 
-  def eval(func, _env) when is_function(func) do
-    func
+  def eval(func, env, store) when is_function(func) do
+    {func, env, store}
   end
 
-  def eval(map, env) when is_map(map) do
-    map
-    |> Enum.map(fn {k, v} -> {eval(k, env), eval(v, env)} end)
-    |> Map.new()
+  def eval(map, env, store) when is_map(map) do
+    {map
+    |> Enum.map(fn {k, v} ->
+       {k, _, _} = eval(k, env, store)
+       {v, _, _} = eval(v, env, store)
+       {k, v} end)
+    |> Map.new(),
+     env, store}
   end
 
-  def eval({:closure, params, body}, _env) do
-    {:closure, params, body}
+  def eval({:closure, params, body, closure_env}, env, store) do
+    {{:closure, params, body, closure_env}, env, store}
   end
 
-  def eval({:native, module, functor}, _env) do
-    {:native, module, functor}
+  def eval({:cell, cell_id}, env, store) do
+    {{:cell, cell_id}, env, store}
+  end
+  
+  def eval({:native, module, functor}, env, store) do
+    {{:native, module, functor}, env, store}
   end
 
-  def eval([op | args], env) do
+  def eval([op | args], env, store) do
+    # IO.inspect(op)
+    # IO.inspect(args)
+    # IO.inspect(env)
     case op do
       :if ->
-        if eval(hd(args), env) do
-          eval(Enum.at(args, 1), env)
+        {cond_statement, _, _} = eval(hd(args), env, store)
+        if cond_statement do
+          eval(Enum.at(args, 1), env, store)
         else
-          eval(Enum.at(args, 2), env)
+          eval(Enum.at(args, 2), env, store)
         end
 
       :quote ->
-        hd(args)
+        {[:quote, hd(args)], env, store}
 
       :list ->
-        [:list | Enum.map(args, fn arg -> eval(arg, env) end)]
+        {[:list | Enum.map(args, fn arg ->
+             {arg, _, _} = eval(arg, env, store)
+             arg
+           end)], env, store}
 
       :car ->
-        case eval(hd(args), env) do
-          [:list | args] -> hd(args)
-          _ -> :err
+        case eval(hd(args), env, store) do
+          {[:list | args], _, _} -> {hd(args), env, store}
+          _ -> :car_err
         end
 
       :cdr ->
-        case eval(hd(args), env) do
-          [:list | args] ->
+        case eval(hd(args), env, store) do
+          {[:list | args], _, _} ->
             if length(args) == 1 do
-              nil
+              {nil, env, store}
             else
-              [:list | tl(args)]
+              {[:list | tl(args)], env, store}
             end
 
           _ ->
-            :err
+            :cdr_err
         end
 
       :cons ->
-        car = eval(hd(args), env)
+        {car, _, _} = eval(hd(args), env, store)
 
-        case eval(Enum.at(args, 1), env) do
-          [:list | args] -> [:list, car | args]
-          nil -> [:list, car]
-          _ -> :err
+        case eval(Enum.at(args, 1), env, store) do
+          {[:list | args], _, _} -> {[:list, car | args], env, store}
+          {nil, _, _} -> {[:list, car], env, store}
+          _ -> :cons_err
         end
 
       :and ->
-        case eval(hd(args), env) do
-          true -> eval(Enum.at(args, 1), env)
-          false -> false
+        case eval(hd(args), env, store) do
+          {true, _, _} -> eval(Enum.at(args, 1), env, store)
+          {false, _, _} -> {false, env, store}
         end
 
       :or ->
-        case eval(hd(args), env) do
-          true -> true
-          false -> eval(Enum.at(args, 1), env)
+        case eval(hd(args), env, store) do
+          {true, _, _} -> {true, env, store}
+          {false, _, _} -> eval(Enum.at(args, 1), env, store)
         end
 
       :lambda ->
-        {:closure, hd(args), Enum.at(args, 1), env}
+        {{:closure, hd(args), Enum.at(args, 1), env}, env, store}
 
-      :apply ->
+      :let ->
+        [name, val, body] = args
+        {val, _, _} = eval(val, env, store)
+        eval(body, Map.put(env, name, val), store)
+
+      :do ->
+        Enum.reduce(args, {nil, env, store},
+          fn arg, {_, acc, store} ->
+            eval(arg, acc, store)
+          end)
+
+      :function ->
+        [name, params, body] = args
+        cell_id = Base.encode16(:crypto.strong_rand_bytes(8))
+        closure_env = Map.put(env, name, {:cell, cell_id})
+        
+        {name, closure_env, Map.put(store, cell_id, {:closure, params, body, closure_env})}
+        
+        :apply ->
         [op, args] = args
 
-        args = eval(args, env)
+        {args, _, _} = eval(args, env, store)
 
-        case eval(op, env) do
-          {:closure, params, body, closure_env} ->
+        case eval(op, env, store) do
+          {{:cell, cell_id}, _, _} ->
+            closure = Map.fetch!(store, cell_id)
+            eval([:apply, closure, args], env, store)
+            
+          {{:closure, params, body, closure_env}, _, _} ->
             call_env =
               Enum.reduce(
                 Enum.zip(params, tl(args)),
@@ -188,27 +222,26 @@ defmodule Anoma.LocalDomain.Scheme do
 
             eval(
               body,
-              Map.put(
-                call_env,
-                :self,
-                {:closure, params, body, closure_env}
-              )
+              call_env,
+              store
             )
 
-          {:native, module, functor} ->
-            apply(module, functor, tl(args))
+          {{:native, module, functor}, _, _} ->
+            {apply(module, functor, tl(args)), env, store}
 
           _ ->
-            :err
+            :op_err
         end
 
       _ ->
-        eval([:apply, op, [:list | args]], env)
+        eval([:apply, op, [:list | args]], env, store)
     end
   end
 
   def eval(expr) do
-    eval(expr, default_env())
+    {env, store} = default_env()
+    {result, _, _} = eval(expr, env, store)
+    result
   end
 
   def ast_to_scheme(n) when is_integer(n) do

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -64,10 +64,53 @@ defmodule Anoma.LocalDomain.Scheme do
   def default_env(extra \\ %{}) do
     {:ok, scheme_fns} = Anoma.LocalDomain.SchemeRegistry.all_scheme()
 
-    Map.merge(
+    map_to_env(Map.merge(
       scheme_fns,
       extra
-    )
+    ))
+  end
+
+  def new_env(), do: {%{}, 0, 1}
+
+  # Put the given binding into the environment
+
+  def put_env({tree, index, next}, name, value) do
+    {Map.put(tree, next, {name, value, index}), next, next+1}
+  end
+
+  # Get the value of the given identifier in the environment
+
+  def get_env({tree, index, next}, search_name) do
+    {name, value, parent} = Map.fetch!(tree, index)
+    if name == search_name do
+      value
+    else
+      get_env({tree, parent, next}, search_name)
+    end
+  end
+
+  # Get the unique identifier for the given environment
+
+  def env_id({tree, index, next}), do: index
+
+  # Reserve a unique environment identifier to filled later
+
+  def reserve_env({tree, index, next}) do
+    {{tree, index, next+1}, next}
+  end
+
+  # Insert the given binding at the given unique identifier
+
+  def insert_env({tree, index, next}, at, name, value) do
+    {Map.put(tree, at, {name, value, index}), at, next}
+  end
+
+  # Convert an ordinary Elixir map into an environment
+
+  def map_to_env(map) do
+    Enum.reduce(map, new_env(), fn {name, value}, acc ->
+      put_env(acc, name, value)
+    end)
   end
 
   def eval(num, _env) when is_number(num) do
@@ -91,7 +134,7 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def eval(var, env) when is_atom(var) do
-    Map.fetch!(env, var)
+    get_env(env, var)
   end
 
   def eval(func, _env) when is_function(func) do
@@ -182,13 +225,13 @@ defmodule Anoma.LocalDomain.Scheme do
                 Enum.zip(params, tl(args)),
                 closure_env,
                 fn {param, arg}, acc ->
-                  Map.put(acc, param, arg)
+                  put_env(acc, param, arg)
                 end
               )
 
             eval(
               body,
-              Map.put(
+              put_env(
                 call_env,
                 :self,
                 {:closure, params, body, closure_env}

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -157,92 +157,70 @@ defmodule Anoma.LocalDomain.Scheme do
     {Map.new(map), env}
   end
 
-  def eval({:closure, params, body, closure_env_id}, env) do
-    {{:closure, params, body, closure_env_id}, env}
-  end
+  def eval(closure = {:closure, _, _, _}, env), do: closure
 
-  def eval({:native, module, functor}, env) do
-    {{:native, module, functor}, env}
-  end
+  def eval(native = {:native, _, _}, env), do: native
 
-  def eval([op | args], env) do
-    case op do
-      :if ->
-        {cond, env} = eval(hd(args), env)
-        if cond do
-          eval(Enum.at(args, 1), env)
-        else
-          eval(Enum.at(args, 2), env)
-        end
-
-      :quote ->
-        {hd(args), env}
-
-      :list -> Enum.map_reduce(args, env, &eval/2)
-
-      :and ->
-        case eval(hd(args), env) do
-          {true, env} -> eval(Enum.at(args, 1), env)
-          {false, env} -> {false, env}
-        end
-
-      :or ->
-        case eval(hd(args), env) do
-          {env, true} -> {true, env}
-          {false, env} -> eval(Enum.at(args, 1), env)
-        end
-
-      :function ->
-        {env, closure_env_id} = reserve_env(env)
-        closure = {:closure, Enum.at(args, 1), tl(tl(args)), closure_env_id}
-        env = insert_env(env, closure_env_id, hd(args), closure)
-        {closure, env}
-        
-        :apply ->
-        [op, args] = args
-
-        {args, env} = eval(args, env)
-
-        case eval(op, env) do
-          {{:closure, params, body, closure_env_id}, env} ->
-            caller_env_id = env_id(env)
-            callee_env =
-              Enum.reduce(
-                Enum.zip(params, args),
-                switch_env(env, closure_env_id),
-                fn {param, arg}, acc ->
-                  put_env(acc, param, arg)
-                end
-              )
-
-            {callee_env, body_env_id} = reserve_env(callee_env)
-
-            {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
-
-            callee_env = insert_env(callee_env, body_env_id, nil, nil)
-
-            {result, env} = Enum.reduce(body, {nil, callee_env}, fn expr, {_result, call_env} -> eval(expr, call_env) end)
-
-            {result, switch_env(env, caller_env_id)}
-
-          {{:native, module, functor}, env} ->
-            {apply(module, functor, args), env}
-
-          _ ->
-            :op_err
-        end
-
-      _ ->
-        eval([:apply, op, [:list | args]], env)
+  def eval([:if, cond, consequent, alternate], env) do
+    {cond, env} = eval(cond, env)
+    if cond do
+      eval(consequent, env)
+    else
+      eval(alternate, env)
     end
   end
+
+  def eval([:and, expr1, expr2], env) do
+    eval([:if, expr1, expr2, false], env)
+  end
+
+  def eval([:or, expr1, expr2], env) do
+    eval([:if, expr1, true, expr2], env)
+  end
+
+  def eval([:list | args], env), do: Enum.map_reduce(args, env, &eval/2)
+
+  def eval([:quote, expr], env), do: {expr, env}
+
+  def eval([:function, name, params | body], env) do
+    {env, closure_env_id} = reserve_env(env)
+    closure = {:closure, params, body, closure_env_id}
+    env = insert_env(env, closure_env_id, name, closure)
+    {closure, env}
+  end
+
+  def eval([:apply, op, args], env) do
+    {args, env} = eval(args, env)
+    {op, env} = eval(op, env)
+    eval_apply(op, args, env)
+  end
+
+  def eval_apply({:closure, params, body, closure_env_id}, args, env) do
+    caller_env_id = env_id(env)
+    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
+    callee_env = switch_env(env, closure_env_id)
+    callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
+    {callee_env, body_env_id} = reserve_env(callee_env)
+    {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
+    callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
+    {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
+    {result, switch_env(env, caller_env_id)}
+  end
+
+  def eval_apply({:native, module, functor}, args, env) do
+    {apply(module, functor, args), env}
+  end
+
+  def eval([op | args], env), do: eval([:apply, op, [:list | args]], env)
+
+  # Evaluate the given expression with a prelude prepended
 
   @doc """
   Evaluate the given expression with a prelude prepended
   """
   def eval(expr) do
     {env, prelude} = default_env()
-    # IO.inspect([[:function, :_, [] | prelude] ++ [expr]])
     eval([[:function, :_, [] | prelude] ++ [expr]], env)
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -221,7 +221,10 @@ defmodule Anoma.LocalDomain.Scheme do
         end
 
       :lambda ->
-        {{:closure, hd(args), Enum.at(args, 1), env_id(env)}, env}
+        {env, closure_env_id} = reserve_env(env)
+        closure = {:closure, hd(args), Enum.at(args, 1), closure_env_id}
+        env = insert_env(env, closure_env_id, :self, closure)
+        {closure, env}
 
       :apply ->
         [op, args] = args
@@ -240,14 +243,7 @@ defmodule Anoma.LocalDomain.Scheme do
                 end
               )
 
-            {result, env} = eval(
-              body,
-              put_env(
-                call_env,
-                :self,
-                {:closure, params, body, closure_env_id}
-              )
-                            )
+            {result, env} = eval(body, call_env)
 
             {result, switch_env(env, caller_env_id)}
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -62,11 +62,11 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def default_env(extra \\ %{}) do
-    {:ok, scheme_fns} = Anoma.LocalDomain.SchemeRegistry.all_scheme()
+    {:ok, {scheme_fns, prelude_fns}} = Anoma.LocalDomain.SchemeRegistry.all_scheme()
 
-    Enum.reduce(extra, scheme_fns, fn {name, value}, acc ->
+    {Enum.reduce(extra, scheme_fns, fn {name, value}, acc ->
       put_env(acc, name, value)
-    end)
+    end), prelude_fns}
   end
 
   def new_env(), do: {%{}, 0, 1}
@@ -275,8 +275,11 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
+  # Evaluate the given expression with a prelude prepended
+
   def eval(expr) do
-    eval(expr, default_env())
+    {env, prelude} = default_env()
+    eval([[:function, :_, [] | prelude] ++ [expr]], env)
   end
 
   def ast_to_scheme(n) when is_integer(n) do

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -138,9 +138,15 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def build_body_env(_, acc), do: acc
 
+  # Guards to recognize special values in the DSL
+
+  defguard is_closure(obj) when is_tuple(obj) and length(obj) == 4 and elem(obj, 0) == :closure
+
+  defguard is_native(obj) when is_tuple(obj) and length(obj) == 3 and elem(obj, 0) == :native
+
   # Evaluate the given expression in the given environment
 
-  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_function(obj) do
+  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_closure(obj) or is_native(obj) do
     {obj, env}
   end
 
@@ -156,10 +162,6 @@ defmodule Anoma.LocalDomain.Scheme do
       {{k, v}, env} end)
     {Map.new(map), env}
   end
-
-  def eval(closure = {:closure, _, _, _}, env), do: closure
-
-  def eval(native = {:native, _, _}, env), do: native
 
   def eval([:if, cond, consequent, alternate], env) do
     {cond, env} = eval(cond, env)
@@ -194,6 +196,8 @@ defmodule Anoma.LocalDomain.Scheme do
     eval(expansion, env)
   end
 
+  # Define function application syntax
+
   def eval([:apply, op, args], env) do
     {args, env} = eval(args, env)
     {op, env} = eval(op, env)
@@ -210,14 +214,19 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def eval_apply({:closure, params, body, closure_env_id}, args, env) do
     caller_env_id = env_id(env)
-    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
+    # Move to the closure/callee's environment
     callee_env = switch_env(env, closure_env_id)
+    # Bind the closure's parameters
+    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
     callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
+    # Bind mutually recursive functions in the body
     {callee_env, body_env_id} = reserve_env(callee_env)
     {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
     callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    # Evaluate the body expressions
     eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
     {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
+    # Move back to the caller's environment
     {result, switch_env(env, caller_env_id)}
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -118,6 +118,16 @@ defmodule Anoma.LocalDomain.Scheme do
     end)
   end
 
+  # Add functions to the environment
+
+  def build_body_env([:function, name, params | body], {env, body_env_id}) do
+    {put_env(env, name, {:closure, params, body, body_env_id}), body_env_id}
+  end
+
+  def build_body_env(_, acc), do: acc
+
+  # Evaluate the given expression in the given environment
+
   def eval(num, env) when is_number(num) do
     {num, env}
   end
@@ -220,10 +230,10 @@ defmodule Anoma.LocalDomain.Scheme do
           {false, env} -> eval(Enum.at(args, 1), env)
         end
 
-      :lambda ->
+      :function ->
         {env, closure_env_id} = reserve_env(env)
-        closure = {:closure, hd(args), Enum.at(args, 1), closure_env_id}
-        env = insert_env(env, closure_env_id, :self, closure)
+        closure = {:closure, Enum.at(args, 1), tl(tl(args)), closure_env_id}
+        env = insert_env(env, closure_env_id, hd(args), closure)
         {closure, env}
 
       :apply ->
@@ -234,7 +244,7 @@ defmodule Anoma.LocalDomain.Scheme do
         case eval(op, env) do
           {{:closure, params, body, closure_env_id}, env} ->
             caller_env_id = env_id(env)
-            call_env =
+            callee_env =
               Enum.reduce(
                 Enum.zip(params, tl(args)),
                 switch_env(env, closure_env_id),
@@ -243,7 +253,13 @@ defmodule Anoma.LocalDomain.Scheme do
                 end
               )
 
-            {result, env} = eval(body, call_env)
+            {callee_env, body_env_id} = reserve_env(callee_env)
+
+            {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
+
+            callee_env = insert_env(callee_env, body_env_id, nil, nil)
+
+            {result, env} = Enum.reduce(body, {nil, callee_env}, fn expr, {_result, call_env} -> eval(expr, call_env) end)
 
             {result, switch_env(env, caller_env_id)}
 
@@ -304,7 +320,8 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def ast_to_scheme({:fn, _, [{:->, _, [inputs, body]}]}) do
     [
-      :lambda,
+      :function,
+      :_,
       Enum.map(inputs, fn i -> ast_to_scheme(i) end),
       ast_to_scheme(body)
     ]

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -196,23 +196,21 @@ defmodule Anoma.LocalDomain.Scheme do
       :quote ->
         {hd(args), env}
 
-      :list ->
-        {list, env} = Enum.map_reduce(args, env, fn arg, env -> eval(arg, env) end)
-        {[:list | list], env}
+      :list -> Enum.map_reduce(args, env, &eval/2)
 
       :car ->
         case eval(hd(args), env) do
-          {[:list | args], env} -> {hd(args), env}
+          {args, env} -> {hd(args), env}
           _ -> :err
         end
 
       :cdr ->
         case eval(hd(args), env) do
-          {[:list | args], env} ->
+          {args, env} ->
             if length(args) == 1 do
               {nil, env}
             else
-              {[:list | tl(args)], env}
+              {tl(args), env}
             end
 
           _ ->
@@ -223,8 +221,8 @@ defmodule Anoma.LocalDomain.Scheme do
         {car, env} = eval(hd(args), env)
 
         case eval(Enum.at(args, 1), env) do
-          {[:list | args], env} -> {[:list, car | args], env}
-          {nil, env} -> {[:list, car], env}
+          {nil, env} -> {[car], env}
+          {args, env} -> {[car | args], env}
           _ -> :err
         end
 
@@ -256,7 +254,7 @@ defmodule Anoma.LocalDomain.Scheme do
             caller_env_id = env_id(env)
             callee_env =
               Enum.reduce(
-                Enum.zip(params, tl(args)),
+                Enum.zip(params, args),
                 switch_env(env, closure_env_id),
                 fn {param, arg}, acc ->
                   put_env(acc, param, arg)
@@ -274,7 +272,7 @@ defmodule Anoma.LocalDomain.Scheme do
             {result, switch_env(env, caller_env_id)}
 
           {{:native, module, functor}, env} ->
-            {apply(module, functor, tl(args)), env}
+            {apply(module, functor, args), env}
 
           _ ->
             :op_err

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -9,10 +9,6 @@ defmodule Anoma.LocalDomain.Scheme do
         accumulate: true
       )
 
-      Module.register_attribute(__MODULE__, :elixir_fns,
-        accumulate: true
-      )
-
       import Anoma.LocalDomain.Scheme
       @before_compile unquote(__MODULE__)
     end
@@ -21,22 +17,18 @@ defmodule Anoma.LocalDomain.Scheme do
   defmacro __before_compile__(env) do
     module = env.module
     scheme_fns = Module.get_attribute(module, :scheme_fns)
-    elixir_fns = Module.get_attribute(module, :elixir_fns)
 
     quote do
       def __scheme_fns__ do
-        unquote(Macro.escape(scheme_fns))
-      end
-
-      def __elixir_fns__ do
-        unquote(Macro.escape(elixir_fns))
+        unquote(Enum.reverse(Macro.escape(scheme_fns)))
       end
 
       # This doesn't work first compilation, only recompilation
-      @after_compile __MODULE__
-      def __after_compile__(_env, _bytecode) do
-        Anoma.LocalDomain.SchemeRegistry.register(unquote(module))
-      end
+      # Also if we care about registration order (we do) we shouldn't do post-compiles
+      # @after_compile __MODULE__
+      # def __after_compile__(_env, _bytecode) do
+      #   Anoma.LocalDomain.SchemeRegistry.register(unquote(module))
+      # end
     end
   end
 
@@ -53,8 +45,10 @@ defmodule Anoma.LocalDomain.Scheme do
         unquote(body_elixir)
       end
 
-      @elixir_fns {unquote(name), unquote(args_scheme),
-                   unquote(Macro.escape(body_elixir))}
+      @scheme_fns {unquote(name), unquote(args_scheme),
+                   unquote(
+                     Anoma.LocalDomain.Scheme.ast_to_scheme(body_elixir)
+                   )}
     end
   end
 
@@ -174,7 +168,7 @@ defmodule Anoma.LocalDomain.Scheme do
         end
 
       :lambda ->
-        {:closure, hd(args), Enum.at(args, 1)}
+        {:closure, hd(args), Enum.at(args, 1), env}
 
       :apply ->
         [op, args] = args
@@ -182,16 +176,24 @@ defmodule Anoma.LocalDomain.Scheme do
         args = eval(args, env)
 
         case eval(op, env) do
-          {:closure, params, body} ->
-            env =
-              Enum.reduce(Enum.zip(params, tl(args)), env, fn {param,
-                                                               arg},
-                                                              acc ->
-                Map.put(acc, param, arg)
-              end)
+          {:closure, params, body, closure_env} ->
+            call_env =
+              Enum.reduce(
+                Enum.zip(params, tl(args)),
+                closure_env,
+                fn {param, arg}, acc ->
+                  Map.put(acc, param, arg)
+                end
+              )
 
-            # require IEx; IEx.pry
-            eval(body, env)
+            eval(
+              body,
+              Map.put(
+                call_env,
+                :self,
+                {:closure, params, body, closure_env}
+              )
+            )
 
           {:native, module, functor} ->
             apply(module, functor, tl(args))
@@ -207,10 +209,6 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def eval(expr) do
     eval(expr, default_env())
-  end
-
-  def ast_to_scheme(args, ast) do
-    {:closure, args, ast_to_scheme(ast)}
   end
 
   def ast_to_scheme(n) when is_integer(n) do

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -232,9 +232,21 @@ defmodule Anoma.LocalDomain.Scheme do
 
   # Recursively expand macros
 
+  def expand_macros({:closure, params, body, closure_env_id}, env) do
+    {body, env} = expand_macros(body, env)
+    {{:closure, params, body, closure_env_id}, env}
+  end
+
   def expand_macros(expr = [:expand, reference | _], env) do
+    # Expand the macros in the reference expression
+    {reference, env} = expand_macros(reference, env)
+    # Evaluate the reference expression - this should result in a function
     {reference, env} = eval(reference, env)
+    # Expand the macros used in the value of the reference expression
+    {reference, env} = expand_macros(reference, env)
+    # Apply the reference expression to representation of this expression
     {expansion, env} = eval_apply(reference, [expr], env)
+    # Finally, attempt to expand the output of the macro
     expand_macros(expansion, env)
   end
 
@@ -263,10 +275,17 @@ defmodule Anoma.LocalDomain.Scheme do
   """
   def eval(exprs) do
     {env, prelude} = default_env()
+    # Add the top-level functions to the prelude
     exprs = prelude ++ exprs
+    # Remove the syntactic sugar for macros
     exprs = Enum.map(exprs, &expand_tuples/1)
-    funcs = build_body_env(exprs, env)
-    {exprs, _} = Enum.map_reduce(exprs, funcs, &expand_macros/2)
+    # Create an environment where all macros are bound
+    macro_env = build_body_env(exprs, env)
+    # Expand all macro calls, macro environment not needed afterwards
+    {exprs, _} = Enum.map_reduce(exprs, macro_env, &expand_macros/2)
+    # Create new environment where all bindings have been expanded
+    env = build_body_env(exprs, env)
+    # Finally evaluate the expanded expressions in the context of an expanded environment
     eval([[:function, :_, [] | exprs]], env)
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -196,12 +196,6 @@ defmodule Anoma.LocalDomain.Scheme do
 
   # Define function application syntax
 
-  def eval([:apply, op, args], env) do
-    {args, env} = eval(args, env)
-    {op, env} = eval(op, env)
-    eval_apply(op, args, env)
-  end
-
   def eval([op | args], env) do
     {args, env} = Enum.map_reduce(args, env, &eval/2)
     {op, env} = eval(op, env)

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -4,7 +4,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
   typedstruct do
     field(:scheme, any(), default: Map.new())
-    field(:ast, any(), default: Map.new())
   end
 
   def start_link(opts) do
@@ -15,84 +14,20 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   def init(_opts) do
     # Start with a standard environment
 
+    natives = %{
+      +: {:native, :erlang, :+},
+      -: {:native, :erlang, :-},
+      ==: {:native, :erlang, :==},
+      get: {:native, Map, :get},
+      put: {:native, Map, :put},
+      not: {:native, :erlang, :not},
+      is_integer: {:native, :erlang, :is_integer},
+      is_number: {:native, :erlang, :is_number}
+    }
+
     std =
       %__MODULE__{
-        ast: %{},
-        scheme: %{
-          +: {:native, :erlang, :+},
-          -: {:native, :erlang, :-},
-          ==: {:native, :erlang, :==},
-          is_number: {:native, :erlang, :is_number},
-          get: {:native, Map, :get},
-          put: {:native, Map, :put},
-          not: {:native, :erlang, :not},
-          length:
-            {:closure, [:xs],
-             [
-               :if,
-               [:==, :xs, nil],
-               0,
-               [:+, 1, [:length, [:cdr, :xs]]]
-             ]},
-          is_integer: {:native, :erlang, :is_integer},
-          at:
-            {:closure, [:xs, :n],
-             [
-               :if,
-               [:==, :n, 0],
-               [:car, :xs],
-               [:at, [:cdr, :xs], [:-, :n, 1]]
-             ]},
-          map:
-            {:closure, [:xs, :f],
-             [
-               :if,
-               [:==, :xs, nil],
-               nil,
-               [
-                 :cons,
-                 [:f, [:car, :xs]],
-                 [:map, [:cdr, :xs], :f]
-               ]
-             ]},
-          filter:
-            {:closure, [:xs, :f],
-             [
-               :if,
-               [:==, :xs, nil],
-               nil,
-               [
-                 :if,
-                 [:f, [:car, :xs]],
-                 [
-                   :cons,
-                   [:car, :xs],
-                   [:filter, [:cdr, :xs], :f]
-                 ],
-                 [:filter, [:cdr, :xs], :f]
-               ]
-             ]},
-          nthcdr:
-            {:closure, [:xs, :n],
-             [
-               :if,
-               [:==, :n, 0],
-               :xs,
-               [:nthcdr, [:cdr, :xs], [:-, :n, 1]]
-             ]},
-          take:
-            {:closure, [:xs, :n],
-             [
-               :if,
-               [:==, :n, 0],
-               nil,
-               [
-                 :cons,
-                 [:car, :xs],
-                 [:take, [:cdr, :xs], [:-, :n, 1]]
-               ]
-             ]}
-        }
+        scheme: natives
       }
 
     {:ok, std}
@@ -103,20 +38,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   Why a process? Because we also need to do this for modules we don't control.
   """
   def register(module) do
-    for {name, args_scheme, ast} <- module.__elixir_fns__() do
-      put_ast(
-        module,
-        name,
-        %{args: args_scheme, ast: ast}
-      )
-
-      put_scheme(
-        name,
-        args_scheme,
-        {module, name}
-      )
-    end
-
     for {name_scheme, args_scheme, body_scheme} <-
           module.__scheme_fns__() do
       put_scheme(
@@ -125,10 +46,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
         body_scheme
       )
     end
-  end
 
-  def put_ast(module, name, %{args: args, ast: ast}) do
-    GenServer.cast(__MODULE__, {:put_ast, module, name, args, ast})
+    :ok
   end
 
   def put_scheme(name_scheme, args_scheme, body_scheme) do
@@ -140,19 +59,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
   def get_scheme(name_scheme) do
     case GenServer.call(__MODULE__, {:get_scheme, name_scheme}) do
-      {:ok, {module, name}} ->
-        {:ok, args, ast} =
-          Anoma.LocalDomain.SchemeRegistry.get_ast(module, name)
-
-        Anoma.LocalDomain.Scheme.ast_to_scheme(args, ast)
-
-      {:ok, body} ->
-        body
+      {:ok, body} -> body
     end
-  end
-
-  def get_ast(module, name) do
-    GenServer.call(__MODULE__, {:get_ast, module, name})
   end
 
   def all_scheme() do
@@ -169,21 +77,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   end
 
   @impl true
-  def handle_cast({:put_ast, module, name, args, ast}, state) do
-    {:noreply,
-     %__MODULE__{
-       state
-       | ast:
-           Map.update(
-             state.ast,
-             module,
-             %{name => %{args: args, ast: ast}},
-             &Map.put(&1, name, %{args: args, ast: ast})
-           )
-     }}
-  end
-
-  @impl true
   def handle_cast(
         {:put_scheme, name_scheme, args_scheme, body_scheme},
         state
@@ -195,10 +88,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
            Map.put(
              state.scheme,
              name_scheme,
-             case body_scheme do
-               {module, name} -> {module, name}
-               body_scheme -> {:closure, args_scheme, body_scheme}
-             end
+             {:closure, args_scheme, body_scheme, state.scheme}
            )
      }}
   end
@@ -207,40 +97,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   def handle_call({:get_scheme, name_scheme}, _from, state) do
     body = Map.get(state.scheme, name_scheme)
     {:reply, {:ok, body}, state}
-  end
-
-  @impl true
-  def handle_call({:get_ast, module, name}, _from, state) do
-    case Map.get(state.ast, module) do
-      nil ->
-        # Lazily register
-        register(module)
-
-        if function_exported?(module, :__elixir_fns__, 0) do
-          {_name, args_scheme, ast} =
-            hd(
-              Enum.filter(
-                module.__elixir_fns__(),
-                fn {name_elixir, _args_scheme, _ast} ->
-                  name == name_elixir
-                end
-              )
-            )
-
-          {:reply, {:ok, args_scheme, ast}, state}
-        else
-          {:reply, :absent, state}
-        end
-
-      mod_store ->
-        case Map.get(mod_store, name) do
-          nil ->
-            {:reply, :absent, state}
-
-          %{args: args_scheme, ast: ast} ->
-            {:reply, {:ok, args_scheme, ast}, state}
-        end
-    end
   end
 
   @impl true

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -31,7 +31,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
       is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null},
       atom_to_string: {:native, Macro, :to_string},
-      string_to_atom: {:native, Code, :string_to_quoted!}
+      string_to_atom: {:native, Code, :string_to_quoted!},
+      is_pair: {:native, Anoma.LocalDomain.SchemeRegistry, :is_pair}
     }
 
     std =
@@ -45,6 +46,10 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   def is_null(obj), do: obj == []
 
   def cons(head, tail), do: [head | tail]
+
+  def is_pair([_ | _]), do: true
+
+  def is_pair(_), do: false
 
   @doc """
   Register all elixir->scheme mappings in a process.

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -74,15 +74,13 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
         {:put_scheme, name_scheme, args_scheme, body_scheme},
         state
       ) do
+    {env, closure_env_id} = Anoma.LocalDomain.Scheme.reserve_env(state.scheme)
+    closure = {:closure, args_scheme, body_scheme, closure_env_id}
+    env = Anoma.LocalDomain.Scheme.insert_env(env, closure_env_id, :self, closure)
     {:noreply,
      %__MODULE__{
        state
-       | scheme:
-           Anoma.LocalDomain.Scheme.put_env(
-             state.scheme,
-             name_scheme,
-             {:closure, args_scheme, body_scheme, Anoma.LocalDomain.Scheme.env_id(state.scheme)}
-           )
+       | scheme: Anoma.LocalDomain.Scheme.put_env(env, name_scheme, closure)
      }}
   end
 

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -16,6 +16,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
     # Start with a standard environment
 
     natives = %{
+      >: {:native, :erlang, :>},
       +: {:native, :erlang, :+},
       -: {:native, :erlang, :-},
       ==: {:native, :erlang, :==},

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -3,7 +3,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   use TypedStruct
 
   typedstruct do
-    field(:scheme, any(), default: Map.new())
+    field(:scheme, any(), default: Anoma.LocalDomain.Scheme.new_env())
   end
 
   def start_link(opts) do
@@ -27,7 +27,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
     std =
       %__MODULE__{
-        scheme: natives
+        scheme: Anoma.LocalDomain.Scheme.map_to_env(natives)
       }
 
     {:ok, std}
@@ -66,14 +66,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   def all_scheme() do
     {:ok, scheme_fns} = GenServer.call(__MODULE__, {:all_scheme})
 
-    {:ok,
-     Enum.map(
-       Map.keys(scheme_fns),
-       fn name_scheme ->
-         {name_scheme, get_scheme(name_scheme)}
-       end
-     )
-     |> Map.new()}
+    {:ok, scheme_fns}
   end
 
   @impl true
@@ -85,17 +78,17 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
      %__MODULE__{
        state
        | scheme:
-           Map.put(
+           Anoma.LocalDomain.Scheme.put_env(
              state.scheme,
              name_scheme,
-             {:closure, args_scheme, body_scheme, Anoma.LocalDomain.Scheme.map_to_env(state.scheme)}
+             {:closure, args_scheme, body_scheme, Anoma.LocalDomain.Scheme.env_id(state.scheme)}
            )
      }}
   end
 
   @impl true
   def handle_call({:get_scheme, name_scheme}, _from, state) do
-    body = Map.get(state.scheme, name_scheme)
+    body = Anoma.LocalDomain.Scheme.get_env(state.scheme, name_scheme)
     {:reply, {:ok, body}, state}
   end
 

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -75,7 +75,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
         state
       ) do
     {env, closure_env_id} = Anoma.LocalDomain.Scheme.reserve_env(state.scheme)
-    closure = {:closure, args_scheme, body_scheme, closure_env_id}
+    closure = {:closure, args_scheme, [body_scheme], closure_env_id}
     env = Anoma.LocalDomain.Scheme.insert_env(env, closure_env_id, name_scheme, closure)
     {:noreply, %__MODULE__{state | scheme: env}}
   end

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -29,7 +29,9 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       cdr: {:native, Kernel, :tl},
       null: [],
       cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
-      is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null}
+      is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null},
+      atom_to_string: {:native, Macro, :to_string},
+      string_to_atom: {:native, Code, :string_to_quoted!}
     }
 
     std =

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -27,7 +27,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       is_number: {:native, :erlang, :is_number},
       car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
       cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
-      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons}
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      null: [],
     }
 
     std =

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -88,7 +88,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
            Map.put(
              state.scheme,
              name_scheme,
-             {:closure, args_scheme, body_scheme, state.scheme}
+             {:closure, args_scheme, body_scheme, Anoma.LocalDomain.Scheme.map_to_env(state.scheme)}
            )
      }}
   end

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -25,10 +25,11 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       not: {:native, :erlang, :not},
       is_integer: {:native, :erlang, :is_integer},
       is_number: {:native, :erlang, :is_number},
-      car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
-      cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
-      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      car: {:native, Kernel, :hd},
+      cdr: {:native, Kernel, :tl},
       null: [],
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null}
     }
 
     std =
@@ -39,13 +40,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
     {:ok, std}
   end
 
-  def car(list), do: hd(list)
-
-  def cdr([elt]), do: nil
-
-  def cdr(list), do: tl(list)
-
-  def cons(head, nil), do: [head]
+  def is_null(obj), do: obj == []
 
   def cons(head, tail), do: [head | tail]
 

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -3,7 +3,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   use TypedStruct
 
   typedstruct do
-    field(:template, any(), default: Map.new())
     field(:scheme, any(), default: Map.new())
     field(:ast, any(), default: Map.new())
   end
@@ -15,109 +14,82 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   @impl true
   def init(_opts) do
     # Start with a standard environment
-    # Note that if you wanna do something to the args you basically need to manipulate it as part of the :template store, E.G., if I want to flip Enum.at(xs, n) to (nth n xs) I should compose nth with a flip
 
     std =
       %__MODULE__{
-        template: %{
-          :erlang => %{
-            +: "+",
-            -: "-",
-            ==: "==",
-            is_number: "number?",
-            not: "not",
-            length: "length",
-            is_integer: "integer?",
-            tl: "cdr",
-            hd: "car",
-            apply: "apply",
-            and: "and",
-            or: "or"
-          },
-          Map => %{
-            get: "get",
-            put: "put"
-          },
-          Enum => %{
-            at: "nth",
-            map: "map",
-            filter: "filter",
-            take: "take"
-          }
-        },
         ast: %{},
         scheme: %{
-          "+" => {"native", :erlang, :+},
-          "-" => {"native", :erlang, :-},
-          "==" => {"native", :erlang, :==},
-          "number?" => {"native", :erlang, :is_number},
-          "get" => {"native", Map, :get},
-          "put" => {"native", Map, :put},
-          "not" => {"native", :erlang, :not},
-          "length" =>
-            {"closure", ["xs"],
+          +: {:native, :erlang, :+},
+          -: {:native, :erlang, :-},
+          ==: {:native, :erlang, :==},
+          is_number: {:native, :erlang, :is_number},
+          get: {:native, Map, :get},
+          put: {:native, Map, :put},
+          not: {:native, :erlang, :not},
+          length:
+            {:closure, [:xs],
              [
-               "if",
-               ["==", "xs", nil],
+               :if,
+               [:==, :xs, nil],
                0,
-               ["+", 1, ["length", ["cdr", "xs"]]]
+               [:+, 1, [:length, [:cdr, :xs]]]
              ]},
-          "integer?" => {"native", :erlang, :is_integer},
-          "nth" =>
-            {"closure", ["xs", "n"],
+          is_integer: {:native, :erlang, :is_integer},
+          at:
+            {:closure, [:xs, :n],
              [
-               "if",
-               ["==", "n", 0],
-               ["car", "xs"],
-               ["nth", ["cdr", "xs"], ["-", "n", 1]]
+               :if,
+               [:==, :n, 0],
+               [:car, :xs],
+               [:at, [:cdr, :xs], [:-, :n, 1]]
              ]},
-          "map" =>
-            {"closure", ["xs", "f"],
+          map:
+            {:closure, [:xs, :f],
              [
-               "if",
-               ["==", "xs", nil],
+               :if,
+               [:==, :xs, nil],
                nil,
                [
-                 "cons",
-                 ["f", ["car", "xs"]],
-                 ["map", ["cdr", "xs"], "f"]
+                 :cons,
+                 [:f, [:car, :xs]],
+                 [:map, [:cdr, :xs], :f]
                ]
              ]},
-          "filter" =>
-            {"closure", ["xs", "f"],
+          filter:
+            {:closure, [:xs, :f],
              [
-               "if",
-               ["==", "xs", nil],
+               :if,
+               [:==, :xs, nil],
                nil,
                [
-                 "if",
-                 ["f", ["car", "xs"]],
+                 :if,
+                 [:f, [:car, :xs]],
                  [
-                   "cons",
-                   ["car", "xs"],
-                   ["filter", ["cdr", "xs"], "f"]
+                   :cons,
+                   [:car, :xs],
+                   [:filter, [:cdr, :xs], :f]
                  ],
-                 ["filter", ["cdr", "xs"], "f"]
+                 [:filter, [:cdr, :xs], :f]
                ]
              ]},
-          "nthcdr" =>
-            {"closure", ["xs", "n"],
+          nthcdr:
+            {:closure, [:xs, :n],
              [
-               "if",
-               ["==", "n", 0],
-               "xs",
-               ["nthcdr", ["cdr", "xs"], ["-", "n", 1]]
+               :if,
+               [:==, :n, 0],
+               :xs,
+               [:nthcdr, [:cdr, :xs], [:-, :n, 1]]
              ]},
-          "take" =>
-            {"closure", ["xs", "n"],
+          take:
+            {:closure, [:xs, :n],
              [
-               "if",
-               ["==", "n", 0],
+               :if,
+               [:==, :n, 0],
                nil,
                [
-                 "cons",
-                 ["car", "xs"],
-                 ["take", ["cdr", "xs"], ["-", "n", 1]]
+                 :cons,
+                 [:car, :xs],
+                 [:take, [:cdr, :xs], [:-, :n, 1]]
                ]
              ]}
         }
@@ -131,17 +103,17 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   Why a process? Because we also need to do this for modules we don't control.
   """
   def register(module) do
-    for {name, args, ast, template} <- module.__risc0_template__() do
-      put_template(
-        module,
-        name,
-        template
-      )
-
+    for {name, args_scheme, ast} <- module.__elixir_fns__() do
       put_ast(
         module,
         name,
-        %{args: args, ast: ast}
+        %{args: args_scheme, ast: ast}
+      )
+
+      put_scheme(
+        name,
+        args_scheme,
+        {module, name}
       )
     end
 
@@ -155,10 +127,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
     end
   end
 
-  def put_template(module, name, template) do
-    GenServer.cast(__MODULE__, {:put_template, module, name, template})
-  end
-
   def put_ast(module, name, %{args: args, ast: ast}) do
     GenServer.cast(__MODULE__, {:put_ast, module, name, args, ast})
   end
@@ -170,16 +138,9 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
     )
   end
 
-  def get_template(module, name) do
-    GenServer.call(__MODULE__, {:get_template, module, name})
-  end
-
   def get_scheme(name_scheme) do
     case GenServer.call(__MODULE__, {:get_scheme, name_scheme}) do
-      {:ok, func} when is_function(func) ->
-        {:name, name} = Function.info(func, :name)
-        {:module, module} = Function.info(func, :module)
-
+      {:ok, {module, name}} ->
         {:ok, args, ast} =
           Anoma.LocalDomain.SchemeRegistry.get_ast(module, name)
 
@@ -205,21 +166,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
        end
      )
      |> Map.new()}
-  end
-
-  @impl true
-  def handle_cast({:put_template, module, name, template_scheme}, state) do
-    {:noreply,
-     %__MODULE__{
-       state
-       | template:
-           Map.update(
-             state.template,
-             module,
-             %{name => template_scheme},
-             &Map.put(&1, name, template_scheme)
-           )
-     }}
   end
 
   @impl true
@@ -250,43 +196,11 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
              state.scheme,
              name_scheme,
              case body_scheme do
-               func when is_function(func) -> func
-               body_scheme -> {"closure", args_scheme, body_scheme}
+               {module, name} -> {module, name}
+               body_scheme -> {:closure, args_scheme, body_scheme}
              end
            )
      }}
-  end
-
-  @impl true
-  def handle_call({:get_template, module, name}, _from, state) do
-    case Map.get(state.template, module) do
-      nil ->
-        # Lazily register
-        register(module)
-
-        if function_exported?(module, :__risc0_template__, 0) do
-          {_name, _args_scheme, _ast, template_scheme} =
-            Enum.find(
-              module.__risc0_template__(),
-              fn {name_elixir, _args_scheme, _ast, _template} ->
-                name == name_elixir
-              end
-            )
-
-          case template_scheme do
-            nil -> {:reply, :absent, state}
-            template_scheme -> {:reply, {:ok, template_scheme}, state}
-          end
-        else
-          {:reply, :absent, state}
-        end
-
-      mod_store ->
-        case Map.get(mod_store, name) do
-          nil -> {:reply, :absent, state}
-          template_scheme -> {:reply, {:ok, template_scheme}, state}
-        end
-    end
   end
 
   @impl true
@@ -297,19 +211,18 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
   @impl true
   def handle_call({:get_ast, module, name}, _from, state) do
-    # We have to convert outside the genserver or we get err
     case Map.get(state.ast, module) do
       nil ->
         # Lazily register
         register(module)
 
-        if function_exported?(module, :__risc0_template__, 0) do
-          {_name, args_scheme, ast, _template_scheme} =
+        if function_exported?(module, :__elixir_fns__, 0) do
+          {_name, args_scheme, ast} =
             hd(
               Enum.filter(
-                module.__risc0_template__(),
-                fn {name_template, _args_scheme, _ast, _template} ->
-                  name == name_template
+                module.__elixir_fns__(),
+                fn {name_elixir, _args_scheme, _ast} ->
+                  name == name_elixir
                 end
               )
             )

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -76,12 +76,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       ) do
     {env, closure_env_id} = Anoma.LocalDomain.Scheme.reserve_env(state.scheme)
     closure = {:closure, args_scheme, body_scheme, closure_env_id}
-    env = Anoma.LocalDomain.Scheme.insert_env(env, closure_env_id, :self, closure)
-    {:noreply,
-     %__MODULE__{
-       state
-       | scheme: Anoma.LocalDomain.Scheme.put_env(env, name_scheme, closure)
-     }}
+    env = Anoma.LocalDomain.Scheme.insert_env(env, closure_env_id, name_scheme, closure)
+    {:noreply, %__MODULE__{state | scheme: env}}
   end
 
   @impl true

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -4,6 +4,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
   typedstruct do
     field(:scheme, any(), default: Map.new())
+    field(:store, any(), default: Map.new())
   end
 
   def start_link(opts) do
@@ -27,7 +28,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
     std =
       %__MODULE__{
-        scheme: natives
+        scheme: natives,
+        store: %{}
       }
 
     {:ok, std}
@@ -46,7 +48,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
         body_scheme
       )
     end
-
+          
     :ok
   end
 
@@ -64,35 +66,29 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   end
 
   def all_scheme() do
-    {:ok, scheme_fns} = GenServer.call(__MODULE__, {:all_scheme})
-
-    {:ok,
-     Enum.map(
-       Map.keys(scheme_fns),
-       fn name_scheme ->
-         {name_scheme, get_scheme(name_scheme)}
-       end
-     )
-     |> Map.new()}
+    GenServer.call(__MODULE__, {:all_scheme})
   end
 
   @impl true
   def handle_cast(
-        {:put_scheme, name_scheme, args_scheme, body_scheme},
-        state
-      ) do
+    {:put_scheme, name_scheme, args_scheme, body_scheme},
+    state
+  ) do
+    cell_id = Base.encode16(:crypto.strong_rand_bytes(8))
+    env = Map.put(state.scheme, name_scheme, {:cell, cell_id})
+    
     {:noreply,
      %__MODULE__{
        state
-       | scheme:
-           Map.put(
-             state.scheme,
-             name_scheme,
-             {:closure, args_scheme, body_scheme, state.scheme}
-           )
+       |
+       scheme: env,
+       store:
+       Map.put(state.store,
+         cell_id,
+         {:closure, args_scheme, body_scheme, env})
      }}
   end
-
+      
   @impl true
   def handle_call({:get_scheme, name_scheme}, _from, state) do
     body = Map.get(state.scheme, name_scheme)
@@ -101,6 +97,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
   @impl true
   def handle_call({:all_scheme}, _from, state) do
-    {:reply, {:ok, state.scheme}, state}
+    {:reply, {:ok, state.scheme, state.store}, state}
   end
 end

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -4,6 +4,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
   typedstruct do
     field(:scheme, any(), default: Anoma.LocalDomain.Scheme.new_env())
+    field(:prelude, any(), default: [])
   end
 
   def start_link(opts) do
@@ -64,9 +65,9 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   end
 
   def all_scheme() do
-    {:ok, scheme_fns} = GenServer.call(__MODULE__, {:all_scheme})
+    {:ok, {scheme_fns, prelude_fns}} = GenServer.call(__MODULE__, {:all_scheme})
 
-    {:ok, scheme_fns}
+    {:ok, {scheme_fns, prelude_fns}}
   end
 
   @impl true
@@ -74,10 +75,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
         {:put_scheme, name_scheme, args_scheme, body_scheme},
         state
       ) do
-    {env, closure_env_id} = Anoma.LocalDomain.Scheme.reserve_env(state.scheme)
-    closure = {:closure, args_scheme, [body_scheme], closure_env_id}
-    env = Anoma.LocalDomain.Scheme.insert_env(env, closure_env_id, name_scheme, closure)
-    {:noreply, %__MODULE__{state | scheme: env}}
+    func = [:function, name_scheme, args_scheme, body_scheme]
+    {:noreply, %__MODULE__{state | prelude: [func | state.prelude]}}
   end
 
   @impl true
@@ -88,6 +87,6 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
   @impl true
   def handle_call({:all_scheme}, _from, state) do
-    {:reply, {:ok, state.scheme}, state}
+    {:reply, {:ok, {state.scheme, state.prelude}}, state}
   end
 end

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -24,7 +24,10 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       put: {:native, Map, :put},
       not: {:native, :erlang, :not},
       is_integer: {:native, :erlang, :is_integer},
-      is_number: {:native, :erlang, :is_number}
+      is_number: {:native, :erlang, :is_number},
+      car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
+      cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons}
     }
 
     std =
@@ -34,6 +37,16 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
     {:ok, std}
   end
+
+  def car(list), do: hd(list)
+
+  def cdr([elt]), do: nil
+
+  def cdr(list), do: tl(list)
+
+  def cons(head, nil), do: [head]
+
+  def cons(head, tail), do: [head | tail]
 
   @doc """
   Register all elixir->scheme mappings in a process.

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -4,7 +4,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme length(xs) do
     [
       :if,
-      [:==, :xs, nil],
+      [:is_null, :xs],
       0,
       [:+, 1, [:length, [:cdr, :xs]]]
     ]
@@ -22,8 +22,8 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme map(xs, f) do
     [
       :if,
-      [:==, :xs, nil],
-      nil,
+      [:is_null, :xs],
+      :null,
       [
         :cons,
         [:f, [:car, :xs]],
@@ -35,8 +35,8 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme filter(xs, f) do
     [
       :if,
-      [:==, :xs, nil],
-      nil,
+      [:is_null, :xs],
+      :null,
       [
         :if,
         [:f, [:car, :xs]],
@@ -63,7 +63,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     [
       :if,
       [:==, :n, 0],
-      nil,
+      :null,
       [
         :cons,
         [:car, :xs],

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -84,15 +84,46 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     [:caddr, [:cdr, :sexpr]]
   end
 
-  defscheme let(sexpr) do
-    [:cons,
-     [:cons,
-      [:string_to_atom, ":function"],
-      [:cons, [:string_to_atom, ":let_aux"],
+  defscheme cdddr(sexpr) do
+    [:cddr, [:cdr, :sexpr]]
+  end
+
+  defscheme cddr(sexpr) do
+    [:cdr, [:cdr, :sexpr]]
+  end
+
+  defscheme quote_aux(sexpr) do
+    [:if, [:is_null, :sexpr],
+     [:string_to_atom, ":null"],
+     [:if, [:is_pair, :sexpr],
+      [:if,
+       [:if, [:==, [:car, :sexpr], [:string_to_atom, ":unquote"]],
+        [:is_null, [:cddr, :sexpr]],
+        false],
+       [:cadr, :sexpr],
        [:cons,
-        [:map, [:caddr, :sexpr], :car],
-        [:cons, [:cadddr, :sexpr], :null]]]],
-     [:map, [:caddr, :sexpr], :cadr]]
+        [:string_to_atom, ":cons"],
+        [:cons,
+         [:quote_aux, [:car, :sexpr]],
+         [:cons, [:quote_aux, [:cdr, :sexpr]], :null]]]],
+      [:cons,
+       [:string_to_atom, ":string_to_atom"],
+       [:cons, [:atom_to_string, :sexpr], :null]]]]
+  end
+
+  defscheme quote(sexpr) do
+    [:quote_aux, [:caddr, :sexpr]]
+  end
+
+  defscheme let(sexpr) do
+    {:quote,
+     [[:function, :let_aux,
+       # binding names
+       [:unquote, [:map, [:caddr, :sexpr], :car]],
+       # body
+       :unquote, [:cdddr, :sexpr]],
+      # binding values
+      :unquote, [:map, [:caddr, :sexpr], :cadr]]}
   end
 
   defscheme apply(fun, args) do

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -92,27 +92,25 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     [:cdr, [:cdr, :sexpr]]
   end
 
-  defscheme quote_aux(sexpr) do
-    [:if, [:is_null, :sexpr],
-     [:string_to_atom, ":null"],
-     [:if, [:is_pair, :sexpr],
-      [:if,
-       [:if, [:==, [:car, :sexpr], [:string_to_atom, ":unquote"]],
-        [:is_null, [:cddr, :sexpr]],
-        false],
-       [:cadr, :sexpr],
-       [:cons,
-        [:string_to_atom, ":cons"],
-        [:cons,
-         [:quote_aux, [:car, :sexpr]],
-         [:cons, [:quote_aux, [:cdr, :sexpr]], :null]]]],
-      [:cons,
-       [:string_to_atom, ":string_to_atom"],
-       [:cons, [:atom_to_string, :sexpr], :null]]]]
-  end
-
   defscheme quote(sexpr) do
-    [:quote_aux, [:caddr, :sexpr]]
+    [[:function, :quote_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":null"],
+       [:if, [:is_pair, :sexpr],
+        [:if,
+         [:if, [:==, [:car, :sexpr], [:string_to_atom, ":unquote"]],
+          [:is_null, [:cddr, :sexpr]],
+          false],
+         [:cadr, :sexpr],
+         [:cons,
+          [:string_to_atom, ":cons"],
+          [:cons,
+           [:quote_aux, [:car, :sexpr]],
+           [:cons, [:quote_aux, [:cdr, :sexpr]], :null]]]],
+        [:cons,
+         [:string_to_atom, ":string_to_atom"],
+         [:cons, [:atom_to_string, :sexpr], :null]]]]
+    ], [:caddr, :sexpr]]
   end
 
   defscheme let(sexpr) do
@@ -124,6 +122,26 @@ defmodule Anoma.LocalDomain.Scheme.Std do
        :unquote, [:cdddr, :sexpr]],
       # binding values
       :unquote, [:map, [:caddr, :sexpr], :cadr]]}
+  end
+
+  defscheme andm(sexpr) do
+    [[:function, :andm_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":true"],
+       {:quote,
+        {:let, [[:and_temp, [:unquote, [:car, :sexpr]]]],
+         [:if, :and_temp, [:unquote, [:andm_aux, [:cdr, :sexpr]]], :and_temp]}}]
+    ], [:cddr, :sexpr]]
+  end
+
+  defscheme orm(sexpr) do
+    [[:function, :orm_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":false"],
+       {:quote,
+        {:let, [[:or_temp, [:unquote, [:car, :sexpr]]]],
+         [:if, :or_temp, :or_temp, [:unquote, [:orm_aux, [:cdr, :sexpr]]]]}}]
+    ], [:cddr, :sexpr]]
   end
 
   defscheme apply(fun, args) do

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -72,29 +72,47 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     ]
   end
 
+  defscheme cadr(sexpr) do
+    [:car, [:cdr, :sexpr]]
+  end
+
+  defscheme caddr(sexpr) do
+    [:cadr, [:cdr, :sexpr]]
+  end
+
+  defscheme cadddr(sexpr) do
+    [:caddr, [:cdr, :sexpr]]
+  end
+
+  defscheme let(sexpr) do
+    [:cons,
+     [:cons,
+      [:string_to_atom, ":function"],
+      [:cons, [:string_to_atom, ":let_aux"],
+       [:cons,
+        [:map, [:caddr, :sexpr], :car],
+        [:cons, [:cadddr, :sexpr], :null]]]],
+     [:map, [:caddr, :sexpr], :cadr]]
+  end
+
   defscheme apply(fun, args) do
     [:if, [:is_null, :args],
      [:fun],
-     [[:function, :_, [:arg0, :args],
+     {:let, [[:arg0, [:car, :args]], [:args, [:cdr, :args]]],
        [:if, [:is_null, :args],
         [:fun, :arg0],
-        [[:function, :_, [:arg1, :args],
+        {:let, [[:arg1, [:car, :args]], [:args, [:cdr, :args]]],
           [:if, [:is_null, :args],
            [:fun, :arg0, :arg1],
-           [[:function, :_, [:arg2, :args],
+           {:let, [[:arg2, [:car, :args]], [:args, [:cdr, :args]]],
              [:if, [:is_null, :args],
               [:fun, :arg0, :arg1, :arg2],
-              [[:function, :_, [:arg3, :args],
+              {:let, [[:arg3, [:car, :args]], [:args, [:cdr, :args]]],
                 [:if, [:is_null, :args],
                  [:fun, :arg0, :arg1, :arg2, :arg3],
-                 [[:function, :_, [:arg4, :args],
+                 {:let, [[:arg4, [:car, :args]], [:args, [:cdr, :args]]],
                    [:if, [:is_null, :args],
                     [:fun, :arg0, :arg1, :arg2, :arg3, :arg4],
-                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4, :args]]
-                 ], [:car, :args], [:cdr, :args]]]
-              ], [:car, :args], [:cdr, :args]]]
-           ], [:car, :args], [:cdr, :args]]]
-        ], [:car, :args], [:cdr, :args]]]
-     ], [:car, :args], [:cdr, :args]]]
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4, :args]]}]}]}]}]}]
   end
 end

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -1,0 +1,74 @@
+defmodule Anoma.LocalDomain.Scheme.Std do
+  use Anoma.LocalDomain.Scheme
+
+  defscheme length(xs) do
+    [
+      :if,
+      [:==, :xs, nil],
+      0,
+      [:+, 1, [:self, [:cdr, :xs]]]
+    ]
+  end
+
+  defscheme at(xs, n) do
+    [
+      :if,
+      [:==, :n, 0],
+      [:car, :xs],
+      [:self, [:cdr, :xs], [:-, :n, 1]]
+    ]
+  end
+
+  defscheme map(xs, f) do
+    [
+      :if,
+      [:==, :xs, nil],
+      nil,
+      [
+        :cons,
+        [:f, [:car, :xs]],
+        [:self, [:cdr, :xs], :f]
+      ]
+    ]
+  end
+
+  defscheme filter(xs, f) do
+    [
+      :if,
+      [:==, :xs, nil],
+      nil,
+      [
+        :if,
+        [:f, [:car, :xs]],
+        [
+          :cons,
+          [:car, :xs],
+          [:self, [:cdr, :xs], :f]
+        ],
+        [:self, [:cdr, :xs], :f]
+      ]
+    ]
+  end
+
+  defscheme nthcdr(xs, n) do
+    [
+      :if,
+      [:==, :n, 0],
+      :xs,
+      [:self, [:cdr, :xs], [:-, :n, 1]]
+    ]
+  end
+
+  defscheme take(xs, n) do
+    [
+      :if,
+      [:==, :n, 0],
+      nil,
+      [
+        :cons,
+        [:car, :xs],
+        [:self, [:cdr, :xs], [:-, :n, 1]]
+      ]
+    ]
+  end
+end

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -144,6 +144,15 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     ], [:cddr, :sexpr]]
   end
 
+  defscheme list(sexpr) do
+    [[:function, :list_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":null"],
+       {:quote,
+        [:cons, [:unquote, [:car, :sexpr]], [:unquote, [:list_aux, [:cdr, :sexpr]]]]}]
+    ], [:cddr, :sexpr]]
+  end
+
   defscheme apply(fun, args) do
     [:if, [:is_null, :args],
      [:fun],

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -71,4 +71,30 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       ]
     ]
   end
+
+  defscheme apply(fun, args) do
+    [:if, [:is_null, :args],
+     [:fun],
+     [[:function, :_, [:arg0, :args],
+       [:if, [:is_null, :args],
+        [:fun, :arg0],
+        [[:function, :_, [:arg1, :args],
+          [:if, [:is_null, :args],
+           [:fun, :arg0, :arg1],
+           [[:function, :_, [:arg2, :args],
+             [:if, [:is_null, :args],
+              [:fun, :arg0, :arg1, :arg2],
+              [[:function, :_, [:arg3, :args],
+                [:if, [:is_null, :args],
+                 [:fun, :arg0, :arg1, :arg2, :arg3],
+                 [[:function, :_, [:arg4, :args],
+                   [:if, [:is_null, :args],
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4],
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4, :args]]
+                 ], [:car, :args], [:cdr, :args]]]
+              ], [:car, :args], [:cdr, :args]]]
+           ], [:car, :args], [:cdr, :args]]]
+        ], [:car, :args], [:cdr, :args]]]
+     ], [:car, :args], [:cdr, :args]]]
+  end
 end

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -6,7 +6,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       :if,
       [:==, :xs, nil],
       0,
-      [:+, 1, [:self, [:cdr, :xs]]]
+      [:+, 1, [:length, [:cdr, :xs]]]
     ]
   end
 
@@ -15,7 +15,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       :if,
       [:==, :n, 0],
       [:car, :xs],
-      [:self, [:cdr, :xs], [:-, :n, 1]]
+      [:at, [:cdr, :xs], [:-, :n, 1]]
     ]
   end
 
@@ -27,7 +27,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       [
         :cons,
         [:f, [:car, :xs]],
-        [:self, [:cdr, :xs], :f]
+        [:map, [:cdr, :xs], :f]
       ]
     ]
   end
@@ -43,9 +43,9 @@ defmodule Anoma.LocalDomain.Scheme.Std do
         [
           :cons,
           [:car, :xs],
-          [:self, [:cdr, :xs], :f]
+          [:filter, [:cdr, :xs], :f]
         ],
-        [:self, [:cdr, :xs], :f]
+        [:filter, [:cdr, :xs], :f]
       ]
     ]
   end
@@ -55,7 +55,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       :if,
       [:==, :n, 0],
       :xs,
-      [:self, [:cdr, :xs], [:-, :n, 1]]
+      [:nthcdr, [:cdr, :xs], [:-, :n, 1]]
     ]
   end
 
@@ -67,7 +67,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       [
         :cons,
         [:car, :xs],
-        [:self, [:cdr, :xs], [:-, :n, 1]]
+        [:take, [:cdr, :xs], [:-, :n, 1]]
       ]
     ]
   end

--- a/lib/local_domain/structures/action.ex
+++ b/lib/local_domain/structures/action.ex
@@ -112,14 +112,14 @@ defmodule Anoma.LocalDomain.Action do
         created: created
       }) do
     %{
-      consumed: [
-        "list"
+      "consumed" => [
+        :list
         | Enum.map(consumed, fn c ->
             Anoma.LocalDomain.ObjToResource.scheme(c)
           end)
       ],
-      created: [
-        "list"
+      "created" => [
+        :list
         | Enum.map(created, fn c ->
             Anoma.LocalDomain.ObjToResource.scheme(c)
           end)

--- a/lib/local_domain/structures/fixed_supply.ex
+++ b/lib/local_domain/structures/fixed_supply.ex
@@ -39,14 +39,8 @@ defmodule Anoma.LocalDomain.FixedSupply do
         ),
         0
       )
-    ) ->
-      "fixed_supply_holds"
+    )
   end
-
-  defscheme(
-    fixed_supply_holds(obj, instance, using),
-    &Anoma.LocalDomain.FixedSupply.fixed_supply_holds/3
-  )
 
   def make_fixed_supply(q) do
     %__MODULE__{
@@ -85,7 +79,10 @@ defimpl Anoma.LocalDomain.ObjToResource,
   end
 
   def scheme(data) do
-    %{quantity: data.quantity, supply_quantity: data.supply_quantity}
+    %{
+      "quantity" => data.quantity,
+      "supply_quantity" => data.supply_quantity
+    }
   end
 
   def related_use(data) do

--- a/lib/local_domain/structures/fixed_supply_intent.ex
+++ b/lib/local_domain/structures/fixed_supply_intent.ex
@@ -54,8 +54,8 @@ defimpl Anoma.LocalDomain.ObjToResource,
 
   def scheme(data) do
     %{
-      quantity: data.quantity,
-      should_create: data.should_create
+      "quantity" => data.quantity,
+      "should_create" => data.should_create
     }
   end
 

--- a/lib/local_domain/structures/resource.ex
+++ b/lib/local_domain/structures/resource.ex
@@ -94,11 +94,10 @@ defimpl Anoma.LocalDomain.ObjToResource, for: Function do
   end
 
   def scheme(data) do
-    {:module, mod} = Function.info(data, :module)
+    {:module, _mod} = Function.info(data, :module)
     {:name, name} = Function.info(data, :name)
 
-    func = Anoma.LocalDomain.Scheme.elixir_fn_to_scheme(mod, name)
-    func
+    name
   end
 
   def related_use(_data) do
@@ -123,10 +122,10 @@ defimpl Anoma.LocalDomain.ObjToResource, for: Anoma.LocalDomain.Resource do
 
   def scheme(x) do
     %{
-      data: Anoma.LocalDomain.ObjToResource.scheme(x.data),
-      logic: Anoma.LocalDomain.Scheme.ast_to_scheme(x.logic),
-      quantity: x.quantity,
-      type: x.type
+      "data" => Anoma.LocalDomain.ObjToResource.scheme(x.data),
+      "logic" => Anoma.LocalDomain.Scheme.ast_to_scheme(x.logic),
+      "quantity" => x.quantity,
+      "type" => Atom.to_string(x.type)
     }
   end
 

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -3,11 +3,70 @@ defmodule Anoma.LocalDomain.Transpile do
   
   typedstruct enforce: true do
     field(:counter, non_neg_integer())
-    field(:cprogram, list())
   end
 
   def new() do
-    %__MODULE__{ counter: 0, cprogram: [] }
+    %__MODULE__{ counter: 0 }
+  end
+
+  # Rename distinct variables to distinct names
+
+  def next_variable_suffix(""), do: 0
+
+  def next_variable_suffix(i), do: i + 1
+
+  def rename_variable(from, mapping, used, base, i \\ "") do
+    reference = String.to_atom("#{base}#{i}")
+    if MapSet.member?(used, reference) do
+      rename_variable(from, mapping, used, base, next_variable_suffix(i))
+    else
+      {reference, Map.put(mapping, from, reference), MapSet.put(used, reference)}
+    end
+  end
+
+  def rename_variable(from, mapping, used) do
+    base = String.replace(String.replace(Atom.to_string(from), "-", "_"), ".", "_")
+    rename_variable(from, mapping, used, base)
+  end
+
+  def rename_variables(expr, _mapping, used) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
+    {expr, used}
+  end
+
+  def rename_variables(expr, mapping, used) when is_atom(expr) do
+    {Map.get(mapping, expr, expr), used}
+  end
+
+  def rename_variables([:if, condition, consequent, alternate], mapping, used) do
+    {condition, used} = rename_variables(condition, mapping, used)
+    {consequent, used} = rename_variables(consequent, mapping, used)
+    {alternate, used} = rename_variables(alternate, mapping, used)
+    {[:if, condition, consequent, alternate], used}
+  end
+
+  def rename_variables([:function, reference, parameters | expressions], mapping, used) do
+    {reference, mapping, used} = rename_variable(reference, mapping, used)
+    {parameters, mapping, used} = for param <- parameters, reduce: {[], mapping, used} do
+      {new_parameters, mapping, used} ->
+        {param, mapping, used} = rename_variable(param, mapping, used)
+        {[param | new_parameters], mapping, used}
+    end
+    {expressions, used} = for expr <- expressions, reduce: {[], used} do
+      {new_expressions, used} ->
+        {expr, used} = rename_variables(expr, mapping, used)
+        {[expr | new_expressions], used}
+    end
+    {[:function, reference, Enum.reverse(parameters) | Enum.reverse(expressions)], used}
+  end
+
+  def rename_variables([reference | arguments], mapping, used) do
+    {reference, used} = rename_variables(reference, mapping, used)
+    {arguments, used} = for arg <- arguments, reduce: {[], used} do
+      {new_arguments, used} ->
+        {arg, used} = rename_variables(arg, mapping, used)
+        {[arg | new_arguments], used}
+    end
+    {[reference | Enum.reverse(arguments)], used}
   end
 
   # Generate a new symbol
@@ -46,15 +105,7 @@ defmodule Anoma.LocalDomain.Transpile do
 
   # Transpile a Scheme expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_binary(expr) do
-    {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
-  end
-
-  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_number(expr) do
-    {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
-  end
-
-  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_boolean(expr) do
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
     {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
   end
 
@@ -160,6 +211,8 @@ defmodule Anoma.LocalDomain.Transpile do
   end
 
   def transpile(state = %__MODULE__{}, expr, target, block, labels) do
+    used = MapSet.new([:return, :if, :switch, :case, :int, :float, :void, :goto, :break, :for, :while])
+    {expr, _} = rename_variables(expr, %{}, used)
     {state, block} = transpile_aux(state, expr, target, block, labels)
     {state, Enum.reverse(block)}
   end

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -34,48 +34,52 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def identifier({:function_declarator, decl, params}, ident), do: {:function_declarator, identifier(decl, ident), params}
 
+  # Assign the expression to the target if it is there, otherwise just evaluate it
+  
+  def maybe_assign_expr(expr, {target_expr, target_type}, block) do
+    [{:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, expr}}} | block]
+  end
+
+  def maybe_assign_expr({:address_of_expr, {:symbol_expr, _}}, nil, block), do: block
+
+  def maybe_assign_expr(expr, nil, block), do: [{:expr_stmt, expr} | block]
+
   # Transpile a Scheme expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, _labels) when is_binary(expr) do
-    assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:symbol_expr, expr}}}}
-    block = [assignment | block]
-    {state, block}
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_binary(expr) do
+    {state, maybe_assign_expr({:symbol_expr, expr}, target, block)}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, _labels) when is_number(expr) do
-    assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:literal_expr, expr}}}}
-    block = [assignment | block]
-    {state, block}
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_number(expr) do
+    {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, _labels) when is_boolean(expr) do
-    assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, expr}}}
-    block = [assignment | block]
-    {state, block}
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_boolean(expr) do
+    {state, maybe_assign_expr(expr, target, block)}
   end
 
   # Transpile a Scheme if expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr = ["if", condition, consequent, alternate], {target_expr, target_type}, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = ["if", condition, consequent, alternate], target, block, labels) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, ccond_name} = gen_sym(state)
     ccond = {:symbol_expr, ccond_name}
     ccond_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
     block = [{:declaration_stmt, specifier(ccond_type), [{identifier(declarator(ccond_type), ccond_name), nil}]} | block]
     {state, block} = transpile_aux(state, condition, {ccond, ccond_type}, block, labels)
-    {state, cconsequent} = transpile_aux(state, consequent, {target_expr, target_type}, [], labels)
-    {state, calternate} = transpile_aux(state, alternate, {target_expr, target_type}, [], labels)
+    {state, cconsequent} = transpile_aux(state, consequent, target, [], labels)
+    {state, calternate} = transpile_aux(state, alternate, target, [], labels)
     ifstmt = {:if_stmt, ccond, Enum.reverse(cconsequent), Enum.reverse(calternate)}
     {state, [ifstmt | block]}
   end
 
   # Transpile a Scheme function expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr = ["function", reference, parameters | expressions], {target_expr, target_type}, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = ["function", reference, parameters | expressions], target, block, labels) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     cparams = for param <- parameters, do: { "uintptr_t", {:identifier_declarator, param}}
     cfunc_decl = {:function_declarator, {:identifier_declarator, reference}, cparams}
-    cfunc_type = {:type_name, "uintptr_t", cfunc_decl}
+    cfunc_type = {:type_name, if target do "auto uintptr_t" else "extern uintptr_t" end, cfunc_decl}
     decl_stmt = {:declaration_stmt, specifier(cfunc_type), [{declarator(cfunc_type), nil}]}
     block = block ++ [decl_stmt]
     {state, cret_name} = gen_sym(state)
@@ -88,13 +92,12 @@ defmodule Anoma.LocalDomain.Transpile do
       end
     funbody = [{:return_stmt, cret} | funbody]
     function = {:function_stmt, specifier(cfunc_type), cfunc_decl, Enum.reverse(funbody)}
-    assign_addr = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:address_of_expr, {:symbol_expr, reference}}}}}
-    {state, [assign_addr | [function | block]]}
+    {state, maybe_assign_expr({:address_of_expr, {:symbol_expr, reference}}, target, [function | block])}
   end
 
   # Transpile a Scheme binary expression to C
-
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], {target_expr, target_type}, block, labels) when reference in ["+", "-", "/", "*", "<<", ">>", "==", "!=", "<", ">", "<=", ">=", "&", "|", "%"] do
+  
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when reference in ["+", "-", "/", "*", "<<", ">>", "==", "!=", "<", ">", "<=", ">=", "&", "|", "%"] do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
@@ -107,13 +110,12 @@ defmodule Anoma.LocalDomain.Transpile do
           {state, block, [carg | cargs]}
       end
     call = {:binary_expr, reference, Enum.at(cargs, 1), Enum.at(cargs, 0)}
-    assign_retval = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, call}}}
-    {state, [assign_retval | block]}
+    {state, maybe_assign_expr(call, target, block)}
   end
 
   # Transpile a Scheme procedure call expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], {target_expr, target_type}, block, labels) when is_binary(reference) do
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when is_binary(reference) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
@@ -126,13 +128,12 @@ defmodule Anoma.LocalDomain.Transpile do
           {state, block, [carg | cargs]}
       end
     call = {:call_expr, {:symbol_expr, reference}, Enum.reverse(cargs)}
-    assign_retval = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, call}}}
-    {state, [assign_retval | block]}
+    {state, maybe_assign_expr(call, target, block)}
   end
 
   # Transpile a Scheme procedure call expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], {target_expr, target_type}, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, cref_name} = gen_sym(state)
     cref = {:symbol_expr, cref_name}
@@ -151,8 +152,7 @@ defmodule Anoma.LocalDomain.Transpile do
           {state, block, [carg | cargs]}
       end
     call = {:call_expr, cref, Enum.reverse(cargs)}
-    assign_retval = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, call}}}
-    {state, [assign_retval | block]}
+    {state, maybe_assign_expr(call, target, block)}
   end
 
   def transpile(state = %__MODULE__{}, expr, target, block, labels) do

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -192,7 +192,9 @@ defmodule Anoma.LocalDomain.Transpile do
         end
         {state, [{:goto_stmt, target} | block]}
       _ ->
-        call = {:call_expr, {:symbol_expr, Atom.to_string(reference)}, Enum.reverse(cargs)}
+        params = for _ <- arguments, do: {"uintptr_t", {:identifier_declarator, ""}}
+        cref_type = {:type_name, "uintptr_t", {:function_declarator, {:pointer_declarator, {:identifier_declarator, ""}}, params}}
+        call = {:call_expr, {:cast_expr, cref_type, {:symbol_expr, Atom.to_string(reference)}}, Enum.reverse(cargs)}
         {state, maybe_assign_expr(call, target, block)}
     end
   end
@@ -219,10 +221,14 @@ defmodule Anoma.LocalDomain.Transpile do
     {state, maybe_assign_expr(call, target, block)}
   end
 
-  def transpile(state = %__MODULE__{}, expr, target \\ nil, block \\ [], tails \\ %{}) do
-    used = MapSet.new([:return, :if, :switch, :case, :int, :float, :void, :goto, :break, :for, :while])
-    {expr, _} = rename_variables(expr, %{}, used)
-    {state, block} = transpile_aux(state, expr, target, block, tails)
+  def transpile(state = %__MODULE__{}, exprs, block \\ [], tails \\ %{}) do
+    used = MapSet.new([:return, :if, :switch, :case, :int, :float, :void, :goto, :break, :for, :while, :include, :double, :do, :continue])
+    {state, block, _used} = for expr <- exprs, reduce: {state, block, used} do
+      {state, block, used} ->
+        {expr, used} = rename_variables(expr, %{}, used)
+        {state, block} = transpile_aux(state, expr, nil, block, tails)
+        {state, block, used}
+    end
     {state, Enum.reverse(block)}
   end
 
@@ -265,7 +271,7 @@ defmodule Anoma.LocalDomain.Transpile do
   def cexpr_to_string({:subscript_expr, expr1, expr2}), do: "#{cexpr_to_string(expr1)}[#{cexpr_to_string(expr2)}]"
 
   def cexpr_to_string({:cast_expr, typename, expr}) do
-    "(#{specifier(typename)} #{declarator_to_string(declarator(typename))}) #{cexpr_to_string(expr)}"
+    "((#{specifier(typename)} #{declarator_to_string(declarator(typename))}) #{cexpr_to_string(expr)})"
   end
 
   def cexpr_to_string({:call_expr, reference, args}) do

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -145,8 +145,9 @@ defmodule Anoma.LocalDomain.Transpile do
     cret_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
     cret = {:symbol_expr, cret_name}
     funbody = [{:declaration_stmt, specifier(cret_type), [{identifier(declarator(cret_type), cret_name), nil}]} | funbody]
+    tails = Map.put(tails, reference, {cfunc_label, parameters})
     {state, funbody} = tails(expressions, {state, funbody}, fn
-      [expression], {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, Map.put(tails, reference, {cfunc_label, parameters}))
+      [expression], {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, tails)
       [expression | _], {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, %{})
     end)
     funbody = [{:return_stmt, cret} | funbody]

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -36,19 +36,19 @@ defmodule Anoma.LocalDomain.Transpile do
 
   # Transpile a Scheme expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, labels) when is_binary(expr) do
+  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, _labels) when is_binary(expr) do
     assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:symbol_expr, expr}}}}
     block = [assignment | block]
     {state, block}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, labels) when is_number(expr) do
+  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, _labels) when is_number(expr) do
     assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:literal_expr, expr}}}}
     block = [assignment | block]
     {state, block}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, labels) when is_boolean(expr) do
+  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, _labels) when is_boolean(expr) do
     assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, expr}}}
     block = [assignment | block]
     {state, block}

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -1,12 +1,12 @@
 defmodule Anoma.LocalDomain.Transpile do
   use TypedStruct
-  
+
   typedstruct enforce: true do
     field(:counter, non_neg_integer())
   end
 
   def new() do
-    %__MODULE__{ counter: 0 }
+    %__MODULE__{counter: 0}
   end
 
   # Rename distinct variables to distinct names
@@ -17,15 +17,28 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def rename_variable(from, {mapping, used}, base, i \\ "") do
     reference = String.to_atom("#{base}#{i}")
+
     if MapSet.member?(used, reference) do
-      rename_variable(from, {mapping, used}, base, next_variable_suffix(i))
+      rename_variable(
+        from,
+        {mapping, used},
+        base,
+        next_variable_suffix(i)
+      )
     else
-      {reference, {Map.put(mapping, from, reference), MapSet.put(used, reference)}}
+      {reference,
+       {Map.put(mapping, from, reference), MapSet.put(used, reference)}}
     end
   end
 
   def rename_variable(from, acc) do
-    base = String.replace(String.replace(Atom.to_string(from), "-", "_"), ".", "_")
+    base =
+      String.replace(
+        String.replace(Atom.to_string(from), "-", "_"),
+        ".",
+        "_"
+      )
+
     rename_variable(from, acc, base)
   end
 
@@ -48,11 +61,13 @@ defmodule Anoma.LocalDomain.Transpile do
 
   # Rename variables in the expression so that distinct instances have different names
 
-  def rename_variables(expr, acc) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
+  def rename_variables(expr, acc)
+      when is_binary(expr) or is_number(expr) or is_boolean(expr) do
     {expr, acc}
   end
 
-  def rename_variables(expr, acc = {mapping, _used}) when is_atom(expr) do
+  def rename_variables(expr, acc = {mapping, _used})
+      when is_atom(expr) do
     {Map.get(mapping, expr, expr), acc}
   end
 
@@ -63,17 +78,30 @@ defmodule Anoma.LocalDomain.Transpile do
     {[:if, condition, consequent, alternate], acc}
   end
 
-  def rename_variables([:function, reference, parameters | expressions], acc = {mapping, _}) do
+  def rename_variables(
+        [:function, reference, parameters | expressions],
+        acc = {mapping, _}
+      ) do
     {reference, acc} = rename_variable(reference, acc)
-    {parameters, inner_acc} = Enum.map_reduce(parameters, acc, &rename_variable/2)
-    {expressions, inner_acc} = Enum.map_reduce(expressions, inner_acc, &rename_function/2)
-    {expressions, {_, used}} = Enum.map_reduce(expressions, inner_acc, &rename_body/2)
+
+    {parameters, inner_acc} =
+      Enum.map_reduce(parameters, acc, &rename_variable/2)
+
+    {expressions, inner_acc} =
+      Enum.map_reduce(expressions, inner_acc, &rename_function/2)
+
+    {expressions, {_, used}} =
+      Enum.map_reduce(expressions, inner_acc, &rename_body/2)
+
     {[:function, reference, parameters | expressions], {mapping, used}}
   end
 
   def rename_variables([reference | arguments], acc) do
     {reference, acc} = rename_variables(reference, acc)
-    {arguments, acc} = Enum.map_reduce(arguments, acc, &rename_variables/2)
+
+    {arguments, acc} =
+      Enum.map_reduce(arguments, acc, &rename_variables/2)
+
     {[reference | arguments], acc}
   end
 
@@ -99,142 +127,383 @@ defmodule Anoma.LocalDomain.Transpile do
 
   # Set the identifier in the given declarator
 
-  def identifier({:identifier_declarator, _}, ident), do: {:identifier_declarator, ident}
+  def identifier({:identifier_declarator, _}, ident),
+    do: {:identifier_declarator, ident}
 
-  def identifier({:pointer_declarator, decl}, ident), do: {:pointer_declarator, identifier(decl, ident)}
+  def identifier({:pointer_declarator, decl}, ident),
+    do: {:pointer_declarator, identifier(decl, ident)}
 
-  def identifier({:array_declarator, decl, expr}, ident), do: {:array_declarator, identifier(decl, ident), expr}
+  def identifier({:array_declarator, decl, expr}, ident),
+    do: {:array_declarator, identifier(decl, ident), expr}
 
-  def identifier({:function_declarator, decl, params}, ident), do: {:function_declarator, identifier(decl, ident), params}
+  def identifier({:function_declarator, decl, params}, ident),
+    do: {:function_declarator, identifier(decl, ident), params}
 
   # Assign the expression to the target if it is there, otherwise just evaluate it
-  
+
   def maybe_assign_expr(expr, {target_expr, target_type}, block) do
-    [{:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, expr}}} | block]
+    [
+      {:expr_stmt,
+       {:binary_expr, "=", target_expr, {:cast_expr, target_type, expr}}}
+      | block
+    ]
   end
 
-  def maybe_assign_expr({:address_of_expr, {:symbol_expr, _}}, nil, block), do: block
+  def maybe_assign_expr(
+        {:address_of_expr, {:symbol_expr, _}},
+        nil,
+        block
+      ),
+      do: block
 
-  def maybe_assign_expr(expr, nil, block), do: [{:expr_stmt, expr} | block]
+  def maybe_assign_expr(expr, nil, block),
+    do: [{:expr_stmt, expr} | block]
 
   # Transpile a Scheme expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr, target, block, _tails) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _tails)
+      when is_binary(expr) or is_number(expr) or is_boolean(expr) do
     {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr, target, block, _tails) when is_atom(expr) do
-    {state, maybe_assign_expr({:symbol_expr, Atom.to_string(expr)}, target, block)}
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _tails)
+      when is_atom(expr) do
+    {state,
+     maybe_assign_expr(
+       {:symbol_expr, Atom.to_string(expr)},
+       target,
+       block
+     )}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr = [:if, condition, consequent, alternate], target, block, tails) do
+  def transpile_aux(
+        state = %__MODULE__{},
+        expr = [:if, condition, consequent, alternate],
+        target,
+        block,
+        tails
+      ) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, ccond_name} = gen_sym(state)
     ccond = {:symbol_expr, ccond_name}
     ccond_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
-    block = [{:declaration_stmt, specifier(ccond_type), [{identifier(declarator(ccond_type), ccond_name), nil}]} | block]
-    {state, block} = transpile_aux(state, condition, {ccond, ccond_type}, block, %{})
-    {state, cconsequent} = transpile_aux(state, consequent, target, [], tails)
-    {state, calternate} = transpile_aux(state, alternate, target, [], tails)
-    ifstmt = {:if_stmt, ccond, Enum.reverse(cconsequent), Enum.reverse(calternate)}
+
+    block = [
+      {:declaration_stmt, specifier(ccond_type),
+       [{identifier(declarator(ccond_type), ccond_name), nil}]}
+      | block
+    ]
+
+    {state, block} =
+      transpile_aux(state, condition, {ccond, ccond_type}, block, %{})
+
+    {state, cconsequent} =
+      transpile_aux(state, consequent, target, [], tails)
+
+    {state, calternate} =
+      transpile_aux(state, alternate, target, [], tails)
+
+    ifstmt =
+      {:if_stmt, ccond, Enum.reverse(cconsequent),
+       Enum.reverse(calternate)}
+
     {state, [ifstmt | block]}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr = [:function, reference, parameters | expressions], target, block, tails) do
+  def transpile_aux(
+        state = %__MODULE__{},
+        expr = [:function, reference, parameters | expressions],
+        target,
+        block,
+        tails
+      ) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
-    cparams = for param <- parameters, do: { "uintptr_t", {:identifier_declarator, Atom.to_string(param)}}
-    cfunc_decl = {:function_declarator, {:identifier_declarator, Atom.to_string(reference)}, cparams}
-    cfunc_type = {:type_name, if target do "auto uintptr_t" else "extern uintptr_t" end, cfunc_decl}
-    decl_stmt = {:declaration_stmt, specifier(cfunc_type), [{declarator(cfunc_type), nil}]}
+
+    cparams =
+      for param <- parameters,
+          do:
+            {"uintptr_t",
+             {:identifier_declarator, Atom.to_string(param)}}
+
+    cfunc_decl =
+      {:function_declarator,
+       {:identifier_declarator, Atom.to_string(reference)}, cparams}
+
+    cfunc_type =
+      {:type_name,
+       if target do
+         "auto uintptr_t"
+       else
+         "extern uintptr_t"
+       end, cfunc_decl}
+
+    decl_stmt =
+      {:declaration_stmt, specifier(cfunc_type),
+       [{declarator(cfunc_type), nil}]}
+
     block = block ++ [decl_stmt]
     {state, cfunc_label} = gen_sym(state)
     funbody = [{:label_stmt, cfunc_label}]
     {state, cret_name} = gen_sym(state)
     cret_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
     cret = {:symbol_expr, cret_name}
-    funbody = [{:declaration_stmt, specifier(cret_type), [{identifier(declarator(cret_type), cret_name), nil}]} | funbody]
+
+    funbody = [
+      {:declaration_stmt, specifier(cret_type),
+       [{identifier(declarator(cret_type), cret_name), nil}]}
+      | funbody
+    ]
+
     tails = Map.put(tails, reference, {cfunc_label, parameters})
-    {state, funbody} = tails(expressions, {state, funbody}, fn
-      [expression], {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, tails)
-      [expression | _], {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, %{})
-    end)
+
+    {state, funbody} =
+      tails(expressions, {state, funbody}, fn
+        [expression], {state, funbody} ->
+          transpile_aux(
+            state,
+            expression,
+            {cret, cret_type},
+            funbody,
+            tails
+          )
+
+        [expression | _], {state, funbody} ->
+          transpile_aux(
+            state,
+            expression,
+            {cret, cret_type},
+            funbody,
+            %{}
+          )
+      end)
+
     funbody = [{:return_stmt, cret} | funbody]
-    funbody = [{:declaration_stmt, "__label__", [{{:identifier_declarator, cfunc_label}, nil}]} | Enum.reverse(funbody)]
-    function = {:function_stmt, specifier(cfunc_type), cfunc_decl, funbody}
-    {state, maybe_assign_expr({:address_of_expr, {:symbol_expr, Atom.to_string(reference)}}, target, [function | block])}
+
+    funbody = [
+      {:declaration_stmt, "__label__",
+       [{{:identifier_declarator, cfunc_label}, nil}]}
+      | Enum.reverse(funbody)
+    ]
+
+    function =
+      {:function_stmt, specifier(cfunc_type), cfunc_decl, funbody}
+
+    {state,
+     maybe_assign_expr(
+       {:address_of_expr, {:symbol_expr, Atom.to_string(reference)}},
+       target,
+       [function | block]
+     )}
   end
-  
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, _tails) when reference in [:+, :-, :/, :*, :"<<", :">>", :==, :!=, :<, :>, :<=, :>=, :&, :|, :%] do
+
+  def transpile_aux(
+        state = %__MODULE__{},
+        expr = [reference | arguments],
+        target,
+        block,
+        _tails
+      )
+      when reference in [
+             :+,
+             :-,
+             :/,
+             :*,
+             :"<<",
+             :">>",
+             :==,
+             :!=,
+             :<,
+             :>,
+             :<=,
+             :>=,
+             :&,
+             :|,
+             :%
+           ] do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
+
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
         {state, block, cargs} ->
           {state, carg_name} = gen_sym(state)
-          carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
-          block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
+
+          carg_type =
+            {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+
+          block = [
+            {:declaration_stmt, specifier(carg_type),
+             [{identifier(declarator(carg_type), carg_name), nil}]}
+            | block
+          ]
+
           carg = {:symbol_expr, carg_name}
-          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, %{})
+
+          {state, block} =
+            transpile_aux(state, arg, {carg, carg_type}, block, %{})
+
           {state, block, [carg | cargs]}
       end
-    call = {:binary_expr, reference, Enum.at(cargs, 1), Enum.at(cargs, 0)}
+
+    call =
+      {:binary_expr, reference, Enum.at(cargs, 1), Enum.at(cargs, 0)}
+
     {state, maybe_assign_expr(call, target, block)}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, tails) when is_atom(reference) do
+  def transpile_aux(
+        state = %__MODULE__{},
+        expr = [reference | arguments],
+        target,
+        block,
+        tails
+      )
+      when is_atom(reference) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
+
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
         {state, block, cargs} ->
           {state, carg_name} = gen_sym(state)
-          carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
-          block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
+
+          carg_type =
+            {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+
+          block = [
+            {:declaration_stmt, specifier(carg_type),
+             [{identifier(declarator(carg_type), carg_name), nil}]}
+            | block
+          ]
+
           carg = {:symbol_expr, carg_name}
-          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, %{})
+
+          {state, block} =
+            transpile_aux(state, arg, {carg, carg_type}, block, %{})
+
           {state, block, [carg | cargs]}
       end
+
     case Map.get(tails, reference) do
       {target, params} ->
-        block = for {param, arg} <- Enum.zip(params, Enum.reverse(cargs)), reduce: block do
-          block -> [{:expr_stmt, {:binary_expr, "=", {:symbol_expr, Atom.to_string(param)}, arg}} | block]
-        end
+        block =
+          for {param, arg} <- Enum.zip(params, Enum.reverse(cargs)),
+              reduce: block do
+            block ->
+              [
+                {:expr_stmt,
+                 {:binary_expr, "=",
+                  {:symbol_expr, Atom.to_string(param)}, arg}}
+                | block
+              ]
+          end
+
         {state, [{:goto_stmt, target} | block]}
+
       _ ->
-        params = for _ <- arguments, do: {"uintptr_t", {:identifier_declarator, ""}}
-        cref_type = {:type_name, "uintptr_t", {:function_declarator, {:pointer_declarator, {:identifier_declarator, ""}}, params}}
-        call = {:call_expr, {:cast_expr, cref_type, {:symbol_expr, Atom.to_string(reference)}}, Enum.reverse(cargs)}
+        params =
+          for _ <- arguments,
+              do: {"uintptr_t", {:identifier_declarator, ""}}
+
+        cref_type =
+          {:type_name, "uintptr_t",
+           {:function_declarator,
+            {:pointer_declarator, {:identifier_declarator, ""}},
+            params}}
+
+        call =
+          {:call_expr,
+           {:cast_expr, cref_type,
+            {:symbol_expr, Atom.to_string(reference)}},
+           Enum.reverse(cargs)}
+
         {state, maybe_assign_expr(call, target, block)}
     end
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, _tails) do
+  def transpile_aux(
+        state = %__MODULE__{},
+        expr = [reference | arguments],
+        target,
+        block,
+        _tails
+      ) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, cref_name} = gen_sym(state)
     cref = {:symbol_expr, cref_name}
-    params = for _ <- arguments, do: {"uintptr_t", {:identifier_declarator, ""}}
-    cref_type = {:type_name, "uintptr_t", {:function_declarator, {:pointer_declarator, {:identifier_declarator, ""}}, params}}
-    block = [{:declaration_stmt, specifier(cref_type), [{identifier(declarator(cref_type), cref_name), nil}]} | block]
-    {state, block} = transpile_aux(state, reference, {cref, cref_type}, block, %{})
+
+    params =
+      for _ <- arguments,
+          do: {"uintptr_t", {:identifier_declarator, ""}}
+
+    cref_type =
+      {:type_name, "uintptr_t",
+       {:function_declarator,
+        {:pointer_declarator, {:identifier_declarator, ""}}, params}}
+
+    block = [
+      {:declaration_stmt, specifier(cref_type),
+       [{identifier(declarator(cref_type), cref_name), nil}]}
+      | block
+    ]
+
+    {state, block} =
+      transpile_aux(state, reference, {cref, cref_type}, block, %{})
+
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
         {state, block, cargs} ->
           {state, carg_name} = gen_sym(state)
-          carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
-          block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
+
+          carg_type =
+            {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+
+          block = [
+            {:declaration_stmt, specifier(carg_type),
+             [{identifier(declarator(carg_type), carg_name), nil}]}
+            | block
+          ]
+
           carg = {:symbol_expr, carg_name}
-          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, %{})
+
+          {state, block} =
+            transpile_aux(state, arg, {carg, carg_type}, block, %{})
+
           {state, block, [carg | cargs]}
       end
+
     call = {:call_expr, cref, Enum.reverse(cargs)}
     {state, maybe_assign_expr(call, target, block)}
   end
 
   def transpile(state = %__MODULE__{}, exprs, block \\ [], tails \\ %{}) do
-    used = MapSet.new([:return, :if, :switch, :case, :int, :float, :void, :goto, :break, :for, :while, :include, :double, :do, :continue])
-    {exprs, acc} = Enum.map_reduce(exprs, {%{}, used}, &rename_function/2)
+    used =
+      MapSet.new([
+        :return,
+        :if,
+        :switch,
+        :case,
+        :int,
+        :float,
+        :void,
+        :goto,
+        :break,
+        :for,
+        :while,
+        :include,
+        :double,
+        :do,
+        :continue
+      ])
+
+    {exprs, acc} =
+      Enum.map_reduce(exprs, {%{}, used}, &rename_function/2)
+
     {exprs, _acc} = Enum.map_reduce(exprs, acc, &rename_body/2)
-    {state, block} = for expr <- exprs, reduce: {state, block} do
-      {state, block} -> transpile_aux(state, expr, nil, block, tails)
-    end
+
+    {state, block} =
+      for expr <- exprs, reduce: {state, block} do
+        {state, block} -> transpile_aux(state, expr, nil, block, tails)
+      end
+
     {state, Enum.reverse(block)}
   end
 
@@ -250,31 +519,41 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def expr_to_string([head | tail]) do
     str =
-      for expr <- tail, reduce: ("(" <> expr_to_string(head)) do
+      for expr <- tail, reduce: "(" <> expr_to_string(head) do
         str -> str <> " " <> expr_to_string(expr)
       end
+
     str <> ")"
   end
 
   # Convert C expression to string
 
-  def cexpr_to_string({:literal_expr, value}) when is_number(value), do: "#{value}"
+  def cexpr_to_string({:literal_expr, value}) when is_number(value),
+    do: "#{value}"
 
-  def cexpr_to_string({:literal_expr, value}) when is_boolean(value), do: "#{value}"
+  def cexpr_to_string({:literal_expr, value}) when is_boolean(value),
+    do: "#{value}"
 
-  def cexpr_to_string({:literal_expr, value}) when is_binary(value), do: "\"#{value}\""
+  def cexpr_to_string({:literal_expr, value}) when is_binary(value),
+    do: "\"#{value}\""
 
-  def cexpr_to_string({:symbol_expr, value}) when is_binary(value), do: "#{value}"
+  def cexpr_to_string({:symbol_expr, value}) when is_binary(value),
+    do: "#{value}"
 
-  def cexpr_to_string({:address_of_expr, expr}), do: "&#{cexpr_to_string(expr)}"
+  def cexpr_to_string({:address_of_expr, expr}),
+    do: "&#{cexpr_to_string(expr)}"
 
-  def cexpr_to_string({:indirection_expr, expr}), do: "*#{cexpr_to_string(expr)}"
-  
-  def cexpr_to_string({:binary_expr, op, expr1, expr2}), do: "(#{cexpr_to_string(expr1)} #{op} #{cexpr_to_string(expr2)})"
+  def cexpr_to_string({:indirection_expr, expr}),
+    do: "*#{cexpr_to_string(expr)}"
 
-  def cexpr_to_string({:not_expr, expr}), do: "!#{cexpr_to_string(expr)}"
+  def cexpr_to_string({:binary_expr, op, expr1, expr2}),
+    do: "(#{cexpr_to_string(expr1)} #{op} #{cexpr_to_string(expr2)})"
 
-  def cexpr_to_string({:subscript_expr, expr1, expr2}), do: "#{cexpr_to_string(expr1)}[#{cexpr_to_string(expr2)}]"
+  def cexpr_to_string({:not_expr, expr}),
+    do: "!#{cexpr_to_string(expr)}"
+
+  def cexpr_to_string({:subscript_expr, expr1, expr2}),
+    do: "#{cexpr_to_string(expr1)}[#{cexpr_to_string(expr2)}]"
 
   def cexpr_to_string({:cast_expr, typename, expr}) do
     "((#{specifier(typename)} #{declarator_to_string(declarator(typename))}) #{cexpr_to_string(expr)})"
@@ -282,39 +561,55 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def cexpr_to_string({:call_expr, reference, args}) do
     str = cexpr_to_string(reference) <> "("
-    str = case args do
-      [arg0 | rest] ->
-        for arg <- rest, reduce: str <> cexpr_to_string(arg0) do
-          str -> str <> ", " <> cexpr_to_string(arg)
-        end
-      [] -> str
-    end
+
+    str =
+      case args do
+        [arg0 | rest] ->
+          for arg <- rest, reduce: str <> cexpr_to_string(arg0) do
+            str -> str <> ", " <> cexpr_to_string(arg)
+          end
+
+        [] ->
+          str
+      end
+
     str <> ")"
   end
 
   # Convert C declaration to string
 
-  def declarator_to_string({:identifier_declarator, ident}) when is_binary(ident), do: "#{ident}"
+  def declarator_to_string({:identifier_declarator, ident})
+      when is_binary(ident),
+      do: "#{ident}"
 
-  def declarator_to_string({:pointer_declarator, decl}), do: "(*#{declarator_to_string(decl)})"
+  def declarator_to_string({:pointer_declarator, decl}),
+    do: "(*#{declarator_to_string(decl)})"
 
-  def declarator_to_string({:array_declarator, decl, expr}), do: "(#{declarator_to_string(decl)}[#{cexpr_to_string(expr)}])"
+  def declarator_to_string({:array_declarator, decl, expr}),
+    do: "(#{declarator_to_string(decl)}[#{cexpr_to_string(expr)}])"
 
   def declarator_to_string({:function_declarator, declarator, params}) do
     str = declarator_to_string(declarator) <> "("
+
     case params do
       [{spec0, decl0} | rest] ->
         str = str <> spec0 <> " " <> declarator_to_string(decl0)
-        str = for {spec, decl} <- rest, reduce: str do
-          str -> str <> ", " <> spec <> " " <> declarator_to_string(decl)
-        end
+
+        str =
+          for {spec, decl} <- rest, reduce: str do
+            str ->
+              str <> ", " <> spec <> " " <> declarator_to_string(decl)
+          end
+
         str <> ")"
-      [] -> str <> ")"
+
+      [] ->
+        str <> ")"
     end
   end
 
   # Convert C initializer to string
-  
+
   def initializer_to_string(nil), do: ""
 
   def initializer_to_string(init), do: " = " <> cexpr_to_string(init)
@@ -323,49 +618,75 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def stmt_to_string({:if_stmt, condition, cons, alt}) do
     str = "if(" <> cexpr_to_string(condition) <> ") {\n"
-    str = for stmt <- cons, reduce: str do
-      str -> str <> stmt_to_string(stmt)
-    end
+
+    str =
+      for stmt <- cons, reduce: str do
+        str -> str <> stmt_to_string(stmt)
+      end
+
     if alt == [] do
       str <> "}\n"
     else
-      str = for stmt <- alt, reduce: str <> "} else {\n" do
-        str -> str <> stmt_to_string(stmt)
-      end
+      str =
+        for stmt <- alt, reduce: str <> "} else {\n" do
+          str -> str <> stmt_to_string(stmt)
+        end
+
       str <> "}\n"
     end
   end
 
-  def stmt_to_string({:return_stmt, val}), do: "return " <> cexpr_to_string(val) <> ";\n"
+  def stmt_to_string({:return_stmt, val}),
+    do: "return " <> cexpr_to_string(val) <> ";\n"
 
-  def stmt_to_string({:comment_stmt, comment}), do: "// " <> comment <> "\n"
+  def stmt_to_string({:comment_stmt, comment}),
+    do: "// " <> comment <> "\n"
 
-  def stmt_to_string({:expr_stmt, expr}), do: cexpr_to_string(expr) <> ";\n"
+  def stmt_to_string({:expr_stmt, expr}),
+    do: cexpr_to_string(expr) <> ";\n"
 
-  def stmt_to_string({:label_stmt, identifier}) when is_binary(identifier), do: identifier <> ":\n"
+  def stmt_to_string({:label_stmt, identifier})
+      when is_binary(identifier),
+      do: identifier <> ":\n"
 
-  def stmt_to_string({:goto_stmt, identifier}) when is_binary(identifier), do: "goto " <> identifier <> ";\n"
+  def stmt_to_string({:goto_stmt, identifier})
+      when is_binary(identifier),
+      do: "goto " <> identifier <> ";\n"
 
   def stmt_to_string({:declaration_stmt, spec, decls}) do
     str = spec
+
     case decls do
       [{decl0, init0} | rest] ->
-        str = str <> " " <> declarator_to_string(decl0) <> initializer_to_string(init0)
+        str =
+          str <>
+            " " <>
+            declarator_to_string(decl0) <> initializer_to_string(init0)
+
         str =
           for {decl, init} <- rest, reduce: str do
-            str -> str <> ", " <> declarator_to_string(decl) <> initializer_to_string(init)
+            str ->
+              str <>
+                ", " <>
+                declarator_to_string(decl) <>
+                initializer_to_string(init)
           end
+
         str <> ";\n"
-      [] -> ";\n"
+
+      [] ->
+        ";\n"
     end
   end
 
   def stmt_to_string({:function_stmt, spec, decl, body}) do
     str = spec <> " " <> declarator_to_string(decl) <> " {\n"
+
     str =
       for stmt <- body, reduce: str do
         str -> str <> stmt_to_string(stmt)
       end
+
     str <> "}\n"
   end
 

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -47,7 +47,7 @@ defmodule Anoma.LocalDomain.Transpile do
   # Transpile a Scheme expression to C
 
   def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_binary(expr) do
-    {state, maybe_assign_expr({:symbol_expr, expr}, target, block)}
+    {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
   end
 
   def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_number(expr) do
@@ -55,12 +55,16 @@ defmodule Anoma.LocalDomain.Transpile do
   end
 
   def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_boolean(expr) do
-    {state, maybe_assign_expr(expr, target, block)}
+    {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
+  end
+
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_atom(expr) do
+    {state, maybe_assign_expr({:symbol_expr, Atom.to_string(expr)}, target, block)}
   end
 
   # Transpile a Scheme if expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr = ["if", condition, consequent, alternate], target, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = [:if, condition, consequent, alternate], target, block, labels) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, ccond_name} = gen_sym(state)
     ccond = {:symbol_expr, ccond_name}
@@ -75,10 +79,10 @@ defmodule Anoma.LocalDomain.Transpile do
 
   # Transpile a Scheme function expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr = ["function", reference, parameters | expressions], target, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = [:function, reference, parameters | expressions], target, block, labels) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
-    cparams = for param <- parameters, do: { "uintptr_t", {:identifier_declarator, param}}
-    cfunc_decl = {:function_declarator, {:identifier_declarator, reference}, cparams}
+    cparams = for param <- parameters, do: { "uintptr_t", {:identifier_declarator, Atom.to_string(param)}}
+    cfunc_decl = {:function_declarator, {:identifier_declarator, Atom.to_string(reference)}, cparams}
     cfunc_type = {:type_name, if target do "auto uintptr_t" else "extern uintptr_t" end, cfunc_decl}
     decl_stmt = {:declaration_stmt, specifier(cfunc_type), [{declarator(cfunc_type), nil}]}
     block = block ++ [decl_stmt]
@@ -92,12 +96,12 @@ defmodule Anoma.LocalDomain.Transpile do
       end
     funbody = [{:return_stmt, cret} | funbody]
     function = {:function_stmt, specifier(cfunc_type), cfunc_decl, Enum.reverse(funbody)}
-    {state, maybe_assign_expr({:address_of_expr, {:symbol_expr, reference}}, target, [function | block])}
+    {state, maybe_assign_expr({:address_of_expr, {:symbol_expr, Atom.to_string(reference)}}, target, [function | block])}
   end
 
   # Transpile a Scheme binary expression to C
   
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when reference in ["+", "-", "/", "*", "<<", ">>", "==", "!=", "<", ">", "<=", ">=", "&", "|", "%"] do
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when reference in [:+, :-, :/, :*, :"<<", :">>", :==, :!=, :<, :>, :<=, :>=, :&, :|, :%] do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
@@ -115,7 +119,7 @@ defmodule Anoma.LocalDomain.Transpile do
 
   # Transpile a Scheme procedure call expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when is_binary(reference) do
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when is_atom(reference) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
@@ -127,7 +131,7 @@ defmodule Anoma.LocalDomain.Transpile do
           {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, labels)
           {state, block, [carg | cargs]}
       end
-    call = {:call_expr, {:symbol_expr, reference}, Enum.reverse(cargs)}
+    call = {:call_expr, {:symbol_expr, Atom.to_string(reference)}, Enum.reverse(cargs)}
     {state, maybe_assign_expr(call, target, block)}
   end
 
@@ -164,7 +168,9 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def expr_to_string(value) when is_number(value), do: "#{value}"
 
-  def expr_to_string(value) when is_binary(value), do: "#{value}"
+  def expr_to_string(value) when is_binary(value), do: "\"#{value}\""
+
+  def expr_to_string(value) when is_atom(value), do: "#{value}"
 
   def expr_to_string([]), do: "()"
 
@@ -179,6 +185,10 @@ defmodule Anoma.LocalDomain.Transpile do
   # Convert C expression to string
 
   def cexpr_to_string({:literal_expr, value}) when is_number(value), do: "#{value}"
+
+  def cexpr_to_string({:literal_expr, value}) when is_boolean(value), do: "#{value}"
+
+  def cexpr_to_string({:literal_expr, value}) when is_binary(value), do: "\"#{value}\""
 
   def cexpr_to_string({:symbol_expr, value}) when is_binary(value), do: "#{value}"
 

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -203,7 +203,7 @@ defmodule Anoma.LocalDomain.Transpile do
         for arg <- rest, reduce: str <> cexpr_to_string(arg0) do
           str -> str <> ", " <> cexpr_to_string(arg)
         end
-      [] -> ""
+      [] -> str
     end
     str <> ")"
   end
@@ -221,7 +221,7 @@ defmodule Anoma.LocalDomain.Transpile do
     case params do
       [{spec0, decl0} | rest] ->
         str = str <> spec0 <> " " <> declarator_to_string(decl0)
-        for {spec, decl} <- rest, reduce: str do
+        str = for {spec, decl} <- rest, reduce: str do
           str -> str <> ", " <> spec <> " " <> declarator_to_string(decl)
         end
         str <> ")"

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -1,0 +1,295 @@
+defmodule Anoma.LocalDomain.Transpile do
+  use TypedStruct
+  
+  typedstruct enforce: true do
+    field(:counter, non_neg_integer())
+    field(:cprogram, list())
+  end
+
+  def new() do
+    %__MODULE__{ counter: 0, cprogram: [] }
+  end
+
+  # Generate a new symbol
+
+  def gen_sym(state = %__MODULE__{}) do
+    sym = "tmp#{state.counter}"
+    state = %__MODULE__{state | counter: state.counter + 1}
+    {state, sym}
+  end
+
+  # Extract the components of a type name
+
+  def specifier({:type_name, spec, _}), do: spec
+
+  def declarator({:type_name, _, decl}), do: decl
+
+  # Set the identifier in the given declarator
+
+  def identifier({:identifier_declarator, _}, ident), do: {:identifier_declarator, ident}
+
+  def identifier({:pointer_declarator, decl}, ident), do: {:pointer_declarator, identifier(decl, ident)}
+
+  def identifier({:array_declarator, decl, expr}, ident), do: {:array_declarator, identifier(decl, ident), expr}
+
+  def identifier({:function_declarator, decl, params}, ident), do: {:function_declarator, identifier(decl, ident), params}
+
+  # Transpile a Scheme expression to C
+
+  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, labels) when is_binary(expr) do
+    assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:symbol_expr, expr}}}}
+    block = [assignment | block]
+    {state, block}
+  end
+
+  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, labels) when is_number(expr) do
+    assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:literal_expr, expr}}}}
+    block = [assignment | block]
+    {state, block}
+  end
+
+  def transpile_aux(state = %__MODULE__{}, expr, {target_expr, target_type}, block, labels) when is_boolean(expr) do
+    assignment = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, expr}}}
+    block = [assignment | block]
+    {state, block}
+  end
+
+  # Transpile a Scheme if expression to C
+
+  def transpile_aux(state = %__MODULE__{}, expr = ["if", condition, consequent, alternate], {target_expr, target_type}, block, labels) do
+    block = [{:comment_stmt, expr_to_string(expr)} | block]
+    {state, ccond_name} = gen_sym(state)
+    ccond = {:symbol_expr, ccond_name}
+    ccond_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+    block = [{:declaration_stmt, specifier(ccond_type), [{identifier(declarator(ccond_type), ccond_name), nil}]} | block]
+    {state, block} = transpile_aux(state, condition, {ccond, ccond_type}, block, labels)
+    {state, cconsequent} = transpile_aux(state, consequent, {target_expr, target_type}, [], labels)
+    {state, calternate} = transpile_aux(state, alternate, {target_expr, target_type}, [], labels)
+    ifstmt = {:if_stmt, ccond, Enum.reverse(cconsequent), Enum.reverse(calternate)}
+    {state, [ifstmt | block]}
+  end
+
+  # Transpile a Scheme function expression to C
+
+  def transpile_aux(state = %__MODULE__{}, expr = ["function", reference, parameters | expressions], {target_expr, target_type}, block, labels) do
+    block = [{:comment_stmt, expr_to_string(expr)} | block]
+    cparams = for param <- parameters, do: { "uintptr_t", {:identifier_declarator, param}}
+    cfunc_decl = {:function_declarator, {:identifier_declarator, reference}, cparams}
+    cfunc_type = {:type_name, "uintptr_t", cfunc_decl}
+    decl_stmt = {:declaration_stmt, specifier(cfunc_type), [{declarator(cfunc_type), nil}]}
+    block = block ++ [decl_stmt]
+    {state, cret_name} = gen_sym(state)
+    cret_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+    cret = {:symbol_expr, cret_name}
+    funbody = [{:declaration_stmt, specifier(cret_type), [{identifier(declarator(cret_type), cret_name), nil}]}]
+    {state, funbody} =
+      for expression <- expressions, reduce: {state, funbody} do
+        {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, labels)
+      end
+    funbody = [{:return_stmt, cret} | funbody]
+    function = {:function_stmt, specifier(cfunc_type), cfunc_decl, Enum.reverse(funbody)}
+    assign_addr = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, {:address_of_expr, {:symbol_expr, reference}}}}}
+    {state, [assign_addr | [function | block]]}
+  end
+
+  # Transpile a Scheme binary expression to C
+
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], {target_expr, target_type}, block, labels) when reference in ["+", "-", "/", "*", "<<", ">>", "==", "!=", "<", ">", "<=", ">=", "&", "|", "%"] do
+    block = [{:comment_stmt, expr_to_string(expr)} | block]
+    {state, block, cargs} =
+      for arg <- arguments, reduce: {state, block, []} do
+        {state, block, cargs} ->
+          {state, carg_name} = gen_sym(state)
+          carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+          block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
+          carg = {:symbol_expr, carg_name}
+          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, labels)
+          {state, block, [carg | cargs]}
+      end
+    call = {:binary_expr, reference, Enum.at(cargs, 1), Enum.at(cargs, 0)}
+    assign_retval = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, call}}}
+    {state, [assign_retval | block]}
+  end
+
+  # Transpile a Scheme procedure call expression to C
+
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], {target_expr, target_type}, block, labels) when is_binary(reference) do
+    block = [{:comment_stmt, expr_to_string(expr)} | block]
+    {state, block, cargs} =
+      for arg <- arguments, reduce: {state, block, []} do
+        {state, block, cargs} ->
+          {state, carg_name} = gen_sym(state)
+          carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+          block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
+          carg = {:symbol_expr, carg_name}
+          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, labels)
+          {state, block, [carg | cargs]}
+      end
+    call = {:call_expr, {:symbol_expr, reference}, Enum.reverse(cargs)}
+    assign_retval = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, call}}}
+    {state, [assign_retval | block]}
+  end
+
+  # Transpile a Scheme procedure call expression to C
+
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], {target_expr, target_type}, block, labels) do
+    block = [{:comment_stmt, expr_to_string(expr)} | block]
+    {state, cref_name} = gen_sym(state)
+    cref = {:symbol_expr, cref_name}
+    params = for _ <- arguments, do: {"uintptr_t", {:identifier_declarator, ""}}
+    cref_type = {:type_name, "uintptr_t", {:function_declarator, {:pointer_declarator, {:identifier_declarator, ""}}, params}}
+    block = [{:declaration_stmt, specifier(cref_type), [{identifier(declarator(cref_type), cref_name), nil}]} | block]
+    {state, block} = transpile_aux(state, reference, {cref, cref_type}, block, labels)
+    {state, block, cargs} =
+      for arg <- arguments, reduce: {state, block, []} do
+        {state, block, cargs} ->
+          {state, carg_name} = gen_sym(state)
+          carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
+          block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
+          carg = {:symbol_expr, carg_name}
+          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, labels)
+          {state, block, [carg | cargs]}
+      end
+    call = {:call_expr, cref, Enum.reverse(cargs)}
+    assign_retval = {:expr_stmt, {:binary_expr, "=", target_expr, {:cast_expr, target_type, call}}}
+    {state, [assign_retval | block]}
+  end
+
+  def transpile(state = %__MODULE__{}, expr, target, block, labels) do
+    {state, block} = transpile_aux(state, expr, target, block, labels)
+    {state, Enum.reverse(block)}
+  end
+
+  # Convert Scheme expression to string
+
+  def expr_to_string(value) when is_number(value), do: "#{value}"
+
+  def expr_to_string(value) when is_binary(value), do: "#{value}"
+
+  def expr_to_string([]), do: "()"
+
+  def expr_to_string([head | tail]) do
+    str =
+      for expr <- tail, reduce: ("(" <> expr_to_string(head)) do
+        str -> str <> " " <> expr_to_string(expr)
+      end
+    str <> ")"
+  end
+
+  # Convert C expression to string
+
+  def cexpr_to_string({:literal_expr, value}) when is_number(value), do: "#{value}"
+
+  def cexpr_to_string({:symbol_expr, value}) when is_binary(value), do: "#{value}"
+
+  def cexpr_to_string({:address_of_expr, expr}), do: "&#{cexpr_to_string(expr)}"
+
+  def cexpr_to_string({:indirection_expr, expr}), do: "*#{cexpr_to_string(expr)}"
+  
+  def cexpr_to_string({:binary_expr, op, expr1, expr2}), do: "(#{cexpr_to_string(expr1)} #{op} #{cexpr_to_string(expr2)})"
+
+  def cexpr_to_string({:not_expr, expr}), do: "!#{cexpr_to_string(expr)}"
+
+  def cexpr_to_string({:subscript_expr, expr1, expr2}), do: "#{cexpr_to_string(expr1)}[#{cexpr_to_string(expr2)}]"
+
+  def cexpr_to_string({:cast_expr, typename, expr}) do
+    "(#{specifier(typename)} #{declarator_to_string(declarator(typename))}) #{cexpr_to_string(expr)}"
+  end
+
+  def cexpr_to_string({:call_expr, reference, args}) do
+    str = cexpr_to_string(reference) <> "("
+    str = case args do
+      [arg0 | rest] ->
+        for arg <- rest, reduce: str <> cexpr_to_string(arg0) do
+          str -> str <> ", " <> cexpr_to_string(arg)
+        end
+      [] -> ""
+    end
+    str <> ")"
+  end
+
+  # Convert C declaration to string
+
+  def declarator_to_string({:identifier_declarator, ident}) when is_binary(ident), do: "#{ident}"
+
+  def declarator_to_string({:pointer_declarator, decl}), do: "(*#{declarator_to_string(decl)})"
+
+  def declarator_to_string({:array_declarator, decl, expr}), do: "(#{declarator_to_string(decl)}[#{cexpr_to_string(expr)}])"
+
+  def declarator_to_string({:function_declarator, declarator, params}) do
+    str = declarator_to_string(declarator) <> "("
+    case params do
+      [{spec0, decl0} | rest] ->
+        str = str <> spec0 <> " " <> declarator_to_string(decl0)
+        for {spec, decl} <- rest, reduce: str do
+          str -> str <> ", " <> spec <> " " <> declarator_to_string(decl)
+        end
+        str <> ")"
+      [] -> str <> ")"
+    end
+  end
+
+  # Convert C initializer to string
+  
+  def initializer_to_string(nil), do: ""
+
+  def initializer_to_string(init), do: " = " <> cexpr_to_string(init)
+
+  # Convert C statement to string
+
+  def stmt_to_string({:if_stmt, condition, cons, alt}) do
+    str = "if(" <> cexpr_to_string(condition) <> ") {\n"
+    str = for stmt <- cons, reduce: str do
+      str -> str <> stmt_to_string(stmt)
+    end
+    if alt == [] do
+      str <> "}\n"
+    else
+      str = for stmt <- alt, reduce: str <> "} else {\n" do
+        str -> str <> stmt_to_string(stmt)
+      end
+      str <> "}\n"
+    end
+  end
+
+  def stmt_to_string({:return_stmt, val}), do: "return " <> cexpr_to_string(val) <> ";\n"
+
+  def stmt_to_string({:comment_stmt, comment}), do: "// " <> comment <> "\n"
+
+  def stmt_to_string({:expr_stmt, expr}), do: cexpr_to_string(expr) <> ";\n"
+
+  def stmt_to_string({:label_stmt, identifier}) when is_binary(identifier), do: identifier <> ":\n"
+
+  def stmt_to_string({:goto_stmt, identifier}) when is_binary(identifier), do: "goto " <> identifier <> ";\n"
+
+  def stmt_to_string({:declaration_stmt, spec, decls}) do
+    str = spec
+    case decls do
+      [{decl0, init0} | rest] ->
+        str = str <> " " <> declarator_to_string(decl0) <> initializer_to_string(init0)
+        str =
+          for {decl, init} <- rest, reduce: str do
+            str -> str <> ", " <> declarator_to_string(decl) <> initializer_to_string(init)
+          end
+        str <> ";\n"
+      [] -> ";\n"
+    end
+  end
+
+  def stmt_to_string({:function_stmt, spec, decl, body}) do
+    str = spec <> " " <> declarator_to_string(decl) <> " {\n"
+    str =
+      for stmt <- body, reduce: str do
+        str -> str <> stmt_to_string(stmt)
+      end
+    str <> "}\n"
+  end
+
+  # Convert C program to string
+
+  def program_to_string(program) do
+    for stmt <- program, reduce: "" do
+      str -> str <> stmt_to_string(stmt)
+    end
+  end
+end

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -29,6 +29,15 @@ defmodule Anoma.LocalDomain.Transpile do
     rename_variable(from, mapping, used, base)
   end
 
+  def rename_variables_aux(expressions, mapping, used) do
+    {expressions, used} = for expr <- expressions, reduce: {[], used} do
+      {new_expressions, used} ->
+        {expr, used} = rename_variables(expr, mapping, used)
+        {[expr | new_expressions], used}
+    end
+    {Enum.reverse(expressions), used}
+  end
+
   def rename_variables(expr, _mapping, used) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
     {expr, used}
   end
@@ -51,22 +60,14 @@ defmodule Anoma.LocalDomain.Transpile do
         {param, mapping, used} = rename_variable(param, mapping, used)
         {[param | new_parameters], mapping, used}
     end
-    {expressions, used} = for expr <- expressions, reduce: {[], used} do
-      {new_expressions, used} ->
-        {expr, used} = rename_variables(expr, mapping, used)
-        {[expr | new_expressions], used}
-    end
-    {[:function, reference, Enum.reverse(parameters) | Enum.reverse(expressions)], used}
+    {expressions, used} = rename_variables_aux(expressions, mapping, used)
+    {[:function, reference, Enum.reverse(parameters) | expressions], used}
   end
 
   def rename_variables([reference | arguments], mapping, used) do
     {reference, used} = rename_variables(reference, mapping, used)
-    {arguments, used} = for arg <- arguments, reduce: {[], used} do
-      {new_arguments, used} ->
-        {arg, used} = rename_variables(arg, mapping, used)
-        {[arg | new_arguments], used}
-    end
-    {[reference | Enum.reverse(arguments)], used}
+    {arguments, used} = rename_variables_aux(arguments, mapping, used)
+    {[reference | arguments], used}
   end
 
   # A variation of Enum.reduce that supplies tails to the function

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -15,59 +15,66 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def next_variable_suffix(i), do: i + 1
 
-  def rename_variable(from, mapping, used, base, i \\ "") do
+  def rename_variable(from, {mapping, used}, base, i \\ "") do
     reference = String.to_atom("#{base}#{i}")
     if MapSet.member?(used, reference) do
-      rename_variable(from, mapping, used, base, next_variable_suffix(i))
+      rename_variable(from, {mapping, used}, base, next_variable_suffix(i))
     else
-      {reference, Map.put(mapping, from, reference), MapSet.put(used, reference)}
+      {reference, {Map.put(mapping, from, reference), MapSet.put(used, reference)}}
     end
   end
 
-  def rename_variable(from, mapping, used) do
+  def rename_variable(from, acc) do
     base = String.replace(String.replace(Atom.to_string(from), "-", "_"), ".", "_")
-    rename_variable(from, mapping, used, base)
+    rename_variable(from, acc, base)
   end
 
-  def rename_variables_aux(expressions, mapping, used) do
-    {expressions, used} = for expr <- expressions, reduce: {[], used} do
-      {new_expressions, used} ->
-        {expr, used} = rename_variables(expr, mapping, used)
-        {[expr | new_expressions], used}
-    end
-    {Enum.reverse(expressions), used}
+  # Do not rename a function if it is used as an internal definition
+
+  def rename_body(expr = [:function, reference, _ | _], {mapping, used}) do
+    rename_variables(expr, {mapping, MapSet.delete(used, reference)})
   end
 
-  def rename_variables(expr, _mapping, used) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
-    {expr, used}
+  def rename_body(expr, acc), do: rename_variables(expr, acc)
+
+  # Rename functions that are used as internal definitions ahead of time
+
+  def rename_function([:function, reference, params | body], acc) do
+    {reference, acc} = rename_variable(reference, acc)
+    {[:function, reference, params | body], acc}
   end
 
-  def rename_variables(expr, mapping, used) when is_atom(expr) do
-    {Map.get(mapping, expr, expr), used}
+  def rename_function(expr, acc), do: {expr, acc}
+
+  # Rename variables in the expression so that distinct instances have different names
+
+  def rename_variables(expr, acc) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
+    {expr, acc}
   end
 
-  def rename_variables([:if, condition, consequent, alternate], mapping, used) do
-    {condition, used} = rename_variables(condition, mapping, used)
-    {consequent, used} = rename_variables(consequent, mapping, used)
-    {alternate, used} = rename_variables(alternate, mapping, used)
-    {[:if, condition, consequent, alternate], used}
+  def rename_variables(expr, acc = {mapping, _used}) when is_atom(expr) do
+    {Map.get(mapping, expr, expr), acc}
   end
 
-  def rename_variables([:function, reference, parameters | expressions], mapping, used) do
-    {reference, mapping, used} = rename_variable(reference, mapping, used)
-    {parameters, mapping, used} = for param <- parameters, reduce: {[], mapping, used} do
-      {new_parameters, mapping, used} ->
-        {param, mapping, used} = rename_variable(param, mapping, used)
-        {[param | new_parameters], mapping, used}
-    end
-    {expressions, used} = rename_variables_aux(expressions, mapping, used)
-    {[:function, reference, Enum.reverse(parameters) | expressions], used}
+  def rename_variables([:if, condition, consequent, alternate], acc) do
+    {condition, acc} = rename_variables(condition, acc)
+    {consequent, acc} = rename_variables(consequent, acc)
+    {alternate, acc} = rename_variables(alternate, acc)
+    {[:if, condition, consequent, alternate], acc}
   end
 
-  def rename_variables([reference | arguments], mapping, used) do
-    {reference, used} = rename_variables(reference, mapping, used)
-    {arguments, used} = rename_variables_aux(arguments, mapping, used)
-    {[reference | arguments], used}
+  def rename_variables([:function, reference, parameters | expressions], acc = {mapping, _}) do
+    {reference, acc} = rename_variable(reference, acc)
+    {parameters, inner_acc} = Enum.map_reduce(parameters, acc, &rename_variable/2)
+    {expressions, inner_acc} = Enum.map_reduce(expressions, inner_acc, &rename_function/2)
+    {expressions, {_, used}} = Enum.map_reduce(expressions, inner_acc, &rename_body/2)
+    {[:function, reference, parameters | expressions], {mapping, used}}
+  end
+
+  def rename_variables([reference | arguments], acc) do
+    {reference, acc} = rename_variables(reference, acc)
+    {arguments, acc} = Enum.map_reduce(arguments, acc, &rename_variables/2)
+    {[reference | arguments], acc}
   end
 
   # A variation of Enum.reduce that supplies tails to the function
@@ -223,11 +230,10 @@ defmodule Anoma.LocalDomain.Transpile do
 
   def transpile(state = %__MODULE__{}, exprs, block \\ [], tails \\ %{}) do
     used = MapSet.new([:return, :if, :switch, :case, :int, :float, :void, :goto, :break, :for, :while, :include, :double, :do, :continue])
-    {state, block, _used} = for expr <- exprs, reduce: {state, block, used} do
-      {state, block, used} ->
-        {expr, used} = rename_variables(expr, %{}, used)
-        {state, block} = transpile_aux(state, expr, nil, block, tails)
-        {state, block, used}
+    {exprs, acc} = Enum.map_reduce(exprs, {%{}, used}, &rename_function/2)
+    {exprs, _acc} = Enum.map_reduce(exprs, acc, &rename_body/2)
+    {state, block} = for expr <- exprs, reduce: {state, block} do
+      {state, block} -> transpile_aux(state, expr, nil, block, tails)
     end
     {state, Enum.reverse(block)}
   end

--- a/lib/local_domain/structures/transpile.ex
+++ b/lib/local_domain/structures/transpile.ex
@@ -69,6 +69,12 @@ defmodule Anoma.LocalDomain.Transpile do
     {[reference | Enum.reverse(arguments)], used}
   end
 
+  # A variation of Enum.reduce that supplies tails to the function
+
+  def tails(list = [_hd | tl], acc, f), do: tails(tl, f.(list, acc), f)
+
+  def tails([], acc, _f), do: acc
+
   # Generate a new symbol
 
   def gen_sym(state = %__MODULE__{}) do
@@ -105,54 +111,51 @@ defmodule Anoma.LocalDomain.Transpile do
 
   # Transpile a Scheme expression to C
 
-  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _tails) when is_binary(expr) or is_number(expr) or is_boolean(expr) do
     {state, maybe_assign_expr({:literal_expr, expr}, target, block)}
   end
 
-  def transpile_aux(state = %__MODULE__{}, expr, target, block, _labels) when is_atom(expr) do
+  def transpile_aux(state = %__MODULE__{}, expr, target, block, _tails) when is_atom(expr) do
     {state, maybe_assign_expr({:symbol_expr, Atom.to_string(expr)}, target, block)}
   end
 
-  # Transpile a Scheme if expression to C
-
-  def transpile_aux(state = %__MODULE__{}, expr = [:if, condition, consequent, alternate], target, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = [:if, condition, consequent, alternate], target, block, tails) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, ccond_name} = gen_sym(state)
     ccond = {:symbol_expr, ccond_name}
     ccond_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
     block = [{:declaration_stmt, specifier(ccond_type), [{identifier(declarator(ccond_type), ccond_name), nil}]} | block]
-    {state, block} = transpile_aux(state, condition, {ccond, ccond_type}, block, labels)
-    {state, cconsequent} = transpile_aux(state, consequent, target, [], labels)
-    {state, calternate} = transpile_aux(state, alternate, target, [], labels)
+    {state, block} = transpile_aux(state, condition, {ccond, ccond_type}, block, %{})
+    {state, cconsequent} = transpile_aux(state, consequent, target, [], tails)
+    {state, calternate} = transpile_aux(state, alternate, target, [], tails)
     ifstmt = {:if_stmt, ccond, Enum.reverse(cconsequent), Enum.reverse(calternate)}
     {state, [ifstmt | block]}
   end
 
-  # Transpile a Scheme function expression to C
-
-  def transpile_aux(state = %__MODULE__{}, expr = [:function, reference, parameters | expressions], target, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = [:function, reference, parameters | expressions], target, block, tails) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     cparams = for param <- parameters, do: { "uintptr_t", {:identifier_declarator, Atom.to_string(param)}}
     cfunc_decl = {:function_declarator, {:identifier_declarator, Atom.to_string(reference)}, cparams}
     cfunc_type = {:type_name, if target do "auto uintptr_t" else "extern uintptr_t" end, cfunc_decl}
     decl_stmt = {:declaration_stmt, specifier(cfunc_type), [{declarator(cfunc_type), nil}]}
     block = block ++ [decl_stmt]
+    {state, cfunc_label} = gen_sym(state)
+    funbody = [{:label_stmt, cfunc_label}]
     {state, cret_name} = gen_sym(state)
     cret_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
     cret = {:symbol_expr, cret_name}
-    funbody = [{:declaration_stmt, specifier(cret_type), [{identifier(declarator(cret_type), cret_name), nil}]}]
-    {state, funbody} =
-      for expression <- expressions, reduce: {state, funbody} do
-        {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, labels)
-      end
+    funbody = [{:declaration_stmt, specifier(cret_type), [{identifier(declarator(cret_type), cret_name), nil}]} | funbody]
+    {state, funbody} = tails(expressions, {state, funbody}, fn
+      [expression], {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, Map.put(tails, reference, {cfunc_label, parameters}))
+      [expression | _], {state, funbody} -> transpile_aux(state, expression, {cret, cret_type}, funbody, %{})
+    end)
     funbody = [{:return_stmt, cret} | funbody]
-    function = {:function_stmt, specifier(cfunc_type), cfunc_decl, Enum.reverse(funbody)}
+    funbody = [{:declaration_stmt, "__label__", [{{:identifier_declarator, cfunc_label}, nil}]} | Enum.reverse(funbody)]
+    function = {:function_stmt, specifier(cfunc_type), cfunc_decl, funbody}
     {state, maybe_assign_expr({:address_of_expr, {:symbol_expr, Atom.to_string(reference)}}, target, [function | block])}
   end
-
-  # Transpile a Scheme binary expression to C
   
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when reference in [:+, :-, :/, :*, :"<<", :">>", :==, :!=, :<, :>, :<=, :>=, :&, :|, :%] do
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, _tails) when reference in [:+, :-, :/, :*, :"<<", :">>", :==, :!=, :<, :>, :<=, :>=, :&, :|, :%] do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
@@ -161,16 +164,14 @@ defmodule Anoma.LocalDomain.Transpile do
           carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
           block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
           carg = {:symbol_expr, carg_name}
-          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, labels)
+          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, %{})
           {state, block, [carg | cargs]}
       end
     call = {:binary_expr, reference, Enum.at(cargs, 1), Enum.at(cargs, 0)}
     {state, maybe_assign_expr(call, target, block)}
   end
 
-  # Transpile a Scheme procedure call expression to C
-
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) when is_atom(reference) do
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, tails) when is_atom(reference) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
@@ -179,23 +180,29 @@ defmodule Anoma.LocalDomain.Transpile do
           carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
           block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
           carg = {:symbol_expr, carg_name}
-          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, labels)
+          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, %{})
           {state, block, [carg | cargs]}
       end
-    call = {:call_expr, {:symbol_expr, Atom.to_string(reference)}, Enum.reverse(cargs)}
-    {state, maybe_assign_expr(call, target, block)}
+    case Map.get(tails, reference) do
+      {target, params} ->
+        block = for {param, arg} <- Enum.zip(params, Enum.reverse(cargs)), reduce: block do
+          block -> [{:expr_stmt, {:binary_expr, "=", {:symbol_expr, Atom.to_string(param)}, arg}} | block]
+        end
+        {state, [{:goto_stmt, target} | block]}
+      _ ->
+        call = {:call_expr, {:symbol_expr, Atom.to_string(reference)}, Enum.reverse(cargs)}
+        {state, maybe_assign_expr(call, target, block)}
+    end
   end
 
-  # Transpile a Scheme procedure call expression to C
-
-  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, labels) do
+  def transpile_aux(state = %__MODULE__{}, expr = [reference | arguments], target, block, _tails) do
     block = [{:comment_stmt, expr_to_string(expr)} | block]
     {state, cref_name} = gen_sym(state)
     cref = {:symbol_expr, cref_name}
     params = for _ <- arguments, do: {"uintptr_t", {:identifier_declarator, ""}}
     cref_type = {:type_name, "uintptr_t", {:function_declarator, {:pointer_declarator, {:identifier_declarator, ""}}, params}}
     block = [{:declaration_stmt, specifier(cref_type), [{identifier(declarator(cref_type), cref_name), nil}]} | block]
-    {state, block} = transpile_aux(state, reference, {cref, cref_type}, block, labels)
+    {state, block} = transpile_aux(state, reference, {cref, cref_type}, block, %{})
     {state, block, cargs} =
       for arg <- arguments, reduce: {state, block, []} do
         {state, block, cargs} ->
@@ -203,17 +210,17 @@ defmodule Anoma.LocalDomain.Transpile do
           carg_type = {:type_name, "uintptr_t", {:identifier_declarator, ""}}
           block = [{:declaration_stmt, specifier(carg_type), [{identifier(declarator(carg_type), carg_name), nil}]} | block]
           carg = {:symbol_expr, carg_name}
-          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, labels)
+          {state, block} = transpile_aux(state, arg, {carg, carg_type}, block, %{})
           {state, block, [carg | cargs]}
       end
     call = {:call_expr, cref, Enum.reverse(cargs)}
     {state, maybe_assign_expr(call, target, block)}
   end
 
-  def transpile(state = %__MODULE__{}, expr, target, block, labels) do
+  def transpile(state = %__MODULE__{}, expr, target \\ nil, block \\ [], tails \\ %{}) do
     used = MapSet.new([:return, :if, :switch, :case, :int, :float, :void, :goto, :break, :for, :while])
     {expr, _} = rename_variables(expr, %{}, used)
-    {state, block} = transpile_aux(state, expr, target, block, labels)
+    {state, block} = transpile_aux(state, expr, target, block, tails)
     {state, Enum.reverse(block)}
   end
 

--- a/test/scheme_test.exs
+++ b/test/scheme_test.exs
@@ -1,8 +1,12 @@
 defmodule SchemeTest do
+  alias Anoma.LocalDomain.SchemeRegistry
   use ExUnit.Case
   doctest Anoma.LocalDomain.Scheme
 
   # Examples.EScheme.__after_compile__([], [])
+
+  SchemeRegistry.register(Anoma.LocalDomain.Scheme.Std)
+  SchemeRegistry.register(Examples.EScheme)
 
   test "Run the examples" do
     Examples.EScheme.list()

--- a/test/scheme_test.exs
+++ b/test/scheme_test.exs
@@ -24,6 +24,9 @@ defmodule SchemeTest do
     Examples.EScheme.put()
     Examples.EScheme.car()
     Examples.EScheme.cdr()
+    Examples.EScheme.let()
+    Examples.EScheme.function()
+    Examples.EScheme.do_macro()
 
     Examples.EScheme.fn_to_scheme()
     Examples.EScheme.struct_to_scheme()

--- a/test/scheme_test.exs
+++ b/test/scheme_test.exs
@@ -10,7 +10,7 @@ defmodule SchemeTest do
     Examples.EScheme.lambda()
     Examples.EScheme.apply()
     Examples.EScheme.native_plus()
-    Examples.EScheme.native_nth()
+    Examples.EScheme.native_at()
     Examples.EScheme.map()
     Examples.EScheme.apply_map()
     Examples.EScheme.filter()

--- a/test/scheme_test.exs
+++ b/test/scheme_test.exs
@@ -25,6 +25,7 @@ defmodule SchemeTest do
     Examples.EScheme.car()
     Examples.EScheme.cdr()
     Examples.EScheme.let()
+    Examples.EScheme.labels()
     Examples.EScheme.function()
     Examples.EScheme.do_macro()
 

--- a/test/scheme_test.exs
+++ b/test/scheme_test.exs
@@ -17,6 +17,7 @@ defmodule SchemeTest do
     Examples.EScheme.native_at()
     Examples.EScheme.map()
     Examples.EScheme.apply_map()
+    Examples.EScheme.mutual_recursion()
     Examples.EScheme.filter()
     Examples.EScheme.nthcdr()
     Examples.EScheme.take()

--- a/test/scheme_test.exs
+++ b/test/scheme_test.exs
@@ -14,6 +14,8 @@ defmodule SchemeTest do
     Examples.EScheme.lambda()
     Examples.EScheme.apply()
     Examples.EScheme.native_plus()
+    Examples.EScheme.and_macro()
+    Examples.EScheme.or_macro()
     Examples.EScheme.native_at()
     Examples.EScheme.map()
     Examples.EScheme.apply_map()

--- a/test/transpile_test.exs
+++ b/test/transpile_test.exs
@@ -4,5 +4,15 @@ defmodule TranspileTest do
 
   test "Run the examples" do
     Examples.ETranspile.transpile_factorial()
+    Examples.ETranspile.transpile_filter()
+    Examples.ETranspile.transpile_take()
+    Examples.ETranspile.transpile_map()
+    Examples.ETranspile.transpile_length()
+    Examples.ETranspile.transpile_nth()
+    Examples.ETranspile.transpile_nthcdr()
+    Examples.ETranspile.transpile_lexical_scoping()
+    Examples.ETranspile.transpile_mutual_recursion()
+    Examples.ETranspile.transpile_nested_mutual_recursion()
+    Examples.ETranspile.transpile_string_literals()
   end
 end

--- a/test/transpile_test.exs
+++ b/test/transpile_test.exs
@@ -1,0 +1,8 @@
+defmodule TranspileTest do
+  use ExUnit.Case
+  doctest Anoma.LocalDomain.Transpile
+
+  test "Run the examples" do
+    Examples.ETranspile.transpile_factorial()
+  end
+end


### PR DESCRIPTION
The target branch of this PR implements an interpreter for a Scheme subset. This PR implements a compiler for a variation of that DSL which is easier to compile to C. Specifically, the following has been implemented:
* A compiler from a Scheme representation using Elixir lists to C code
* Tail call optimization to guarantee that tail recursion never blows the stack (probably unnecessary because GCC -O3 has been able to detect and optimize all tail calls so far)
* Moved from using lists of string to lists of symbols to represent Scheme code. Doing this simplified the representation of string literals in the source Scheme programs
* Implemented variable renaming in order to avoid name clashes and avoid C reserved keywords from being used as variable names in the compiler's C output
* Anonymous functions (keyword: `lambda`) are replaced with named functions (keyword: `function`) to enable (mutually) recursive bindings. Furthermore these `function`s can be used as top-level definitions.
  * A key limitation of these anonymous functions is that they cannot be used after the function containing it returns because the function pointer essentially becomes a dangling pointer
* Used lexical scoping instead of dynamic scoping. This is easier to compile because GCC nested functions are also lexically scoped. More generally, lexical scoping is probably easier to compile to fast code because it allows stack frames and variable offsets to be fixed statically.

A way to use the compiler's C output inside RISC Zero is demonstrated at https://github.com/anoma/risc0-scheme . Essentially the C code is copied and pasted into https://github.com/anoma/risc0-scheme/blob/main/methods/guest/src/main.c , though it should be noted that the library functions provided in the compiled environment are slightly different to simplify the compiler outputs.