### PR TITLE
Jam+murisi/feature/elixir resource machine+further experiments2

### DIFF
--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -41,7 +41,7 @@ defmodule Examples.EScheme do
   def map() do
     expr = [:map, list(), lambda()]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 2, 3, 4]
+    assert result == [2, 3, 4]
     result
   end
 
@@ -88,21 +88,21 @@ defmodule Examples.EScheme do
     filter = [:function, :_, [:x], [:==, :x, 1]]
     expr = [:filter, list(), filter]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 1]
+    assert result == [1]
     result
   end
 
   def nthcdr() do
     expr = [:nthcdr, list(), 2]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 3]
+    assert result == [3]
     result
   end
 
   def take() do
     expr = [:take, list(), 2]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 1, 2]
+    assert result == [1, 2]
     result
   end
 
@@ -124,7 +124,7 @@ defmodule Examples.EScheme do
 
   def cdr() do
     {result, _env} = Scheme.eval([:cdr, list()])
-    assert result == [:list, 2, 3]
+    assert result == [2, 3]
     result
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -137,33 +137,15 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def build_body_env(_, acc), do: acc
-  
-  def eval(num, env) when is_number(num) do
-    {num, env}
-  end
 
-  def eval(true, env) do
-    {true, env}
-  end
+  # Evaluate the given expression in the given environment
 
-  def eval(false, env) do
-    {false, env}
-  end
-
-  def eval(nil, env) do
-    {nil, env}
-  end
-
-  def eval(str, env) when is_binary(str) do
-    {str, env}
+  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_function(obj) do
+    {obj, env}
   end
 
   def eval(var, env) when is_atom(var) do
     {get_env(env, var), env}
-  end
-
-  def eval(func, env) when is_function(func) do
-    {func, env}
   end
 
   def eval(map, env) when is_map(map) do

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -170,16 +170,6 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
-  def eval([:and, expr1, expr2], env) do
-    eval([:if, expr1, expr2, false], env)
-  end
-
-  def eval([:or, expr1, expr2], env) do
-    eval([:if, expr1, true, expr2], env)
-  end
-
-  def eval([:list | args], env), do: Enum.map_reduce(args, env, &eval/2)
-
   def eval([:quote, expr], env), do: {expr, env}
 
   def eval([:function, name, params | body], env) do
@@ -189,11 +179,34 @@ defmodule Anoma.LocalDomain.Scheme do
     {closure, env}
   end
 
+  # Define evaluate by reducing to simpler expressions
+
+  def eval([:and, expr1, expr2], env) do
+    eval([:if, expr1, expr2, false], env)
+  end
+
+  def eval([:or, expr1, expr2], env) do
+    eval([:if, expr1, true, expr2], env)
+  end
+
+  def eval([:list | args], env) do
+    expansion = Enum.reduce(Enum.reverse(args), :null, fn elt, acc -> [:cons, elt, acc] end)
+    eval(expansion, env)
+  end
+
   def eval([:apply, op, args], env) do
     {args, env} = eval(args, env)
     {op, env} = eval(op, env)
     eval_apply(op, args, env)
   end
+
+  def eval([op | args], env) do
+    {args, env} = Enum.map_reduce(args, env, &eval/2)
+    {op, env} = eval(op, env)
+    eval_apply(op, args, env)
+  end
+
+  # Apply the given arguments to the given function
 
   def eval_apply({:closure, params, body, closure_env_id}, args, env) do
     caller_env_id = env_id(env)
@@ -211,8 +224,6 @@ defmodule Anoma.LocalDomain.Scheme do
   def eval_apply({:native, module, functor}, args, env) do
     {apply(module, functor, args), env}
   end
-
-  def eval([op | args], env), do: eval([:apply, op, [:list | args]], env)
 
   # Evaluate the given expression with a prelude prepended
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -198,34 +198,6 @@ defmodule Anoma.LocalDomain.Scheme do
 
       :list -> Enum.map_reduce(args, env, &eval/2)
 
-      :car ->
-        case eval(hd(args), env) do
-          {args, env} -> {hd(args), env}
-          _ -> :err
-        end
-
-      :cdr ->
-        case eval(hd(args), env) do
-          {args, env} ->
-            if length(args) == 1 do
-              {nil, env}
-            else
-              {tl(args), env}
-            end
-
-          _ ->
-            :cdr_err
-        end
-
-      :cons ->
-        {car, env} = eval(hd(args), env)
-
-        case eval(Enum.at(args, 1), env) do
-          {nil, env} -> {[car], env}
-          {args, env} -> {[car | args], env}
-          _ -> :err
-        end
-
       :and ->
         case eval(hd(args), env) do
           {true, env} -> eval(Enum.at(args, 1), env)

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -172,8 +172,6 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
-  def eval([:quote, expr], env), do: {expr, env}
-
   def eval([:function, name, params | body], env) do
     {env, closure_env_id} = reserve_env(env)
     closure = {:closure, params, body, closure_env_id}

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -157,92 +157,70 @@ defmodule Anoma.LocalDomain.Scheme do
     {Map.new(map), env}
   end
 
-  def eval({:closure, params, body, closure_env_id}, env) do
-    {{:closure, params, body, closure_env_id}, env}
-  end
+  def eval(closure = {:closure, _, _, _}, env), do: closure
 
-  def eval({:native, module, functor}, env) do
-    {{:native, module, functor}, env}
-  end
+  def eval(native = {:native, _, _}, env), do: native
 
-  def eval([op | args], env) do
-    case op do
-      :if ->
-        {cond, env} = eval(hd(args), env)
-        if cond do
-          eval(Enum.at(args, 1), env)
-        else
-          eval(Enum.at(args, 2), env)
-        end
-
-      :quote ->
-        {hd(args), env}
-
-      :list -> Enum.map_reduce(args, env, &eval/2)
-
-      :and ->
-        case eval(hd(args), env) do
-          {true, env} -> eval(Enum.at(args, 1), env)
-          {false, env} -> {false, env}
-        end
-
-      :or ->
-        case eval(hd(args), env) do
-          {env, true} -> {true, env}
-          {false, env} -> eval(Enum.at(args, 1), env)
-        end
-
-      :function ->
-        {env, closure_env_id} = reserve_env(env)
-        closure = {:closure, Enum.at(args, 1), tl(tl(args)), closure_env_id}
-        env = insert_env(env, closure_env_id, hd(args), closure)
-        {closure, env}
-        
-        :apply ->
-        [op, args] = args
-
-        {args, env} = eval(args, env)
-
-        case eval(op, env) do
-          {{:closure, params, body, closure_env_id}, env} ->
-            caller_env_id = env_id(env)
-            callee_env =
-              Enum.reduce(
-                Enum.zip(params, args),
-                switch_env(env, closure_env_id),
-                fn {param, arg}, acc ->
-                  put_env(acc, param, arg)
-                end
-              )
-
-            {callee_env, body_env_id} = reserve_env(callee_env)
-
-            {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
-
-            callee_env = insert_env(callee_env, body_env_id, nil, nil)
-
-            {result, env} = Enum.reduce(body, {nil, callee_env}, fn expr, {_result, call_env} -> eval(expr, call_env) end)
-
-            {result, switch_env(env, caller_env_id)}
-
-          {{:native, module, functor}, env} ->
-            {apply(module, functor, args), env}
-
-          _ ->
-            :op_err
-        end
-
-      _ ->
-        eval([:apply, op, [:list | args]], env)
+  def eval([:if, cond, consequent, alternate], env) do
+    {cond, env} = eval(cond, env)
+    if cond do
+      eval(consequent, env)
+    else
+      eval(alternate, env)
     end
   end
+
+  def eval([:and, expr1, expr2], env) do
+    eval([:if, expr1, expr2, false], env)
+  end
+
+  def eval([:or, expr1, expr2], env) do
+    eval([:if, expr1, true, expr2], env)
+  end
+
+  def eval([:list | args], env), do: Enum.map_reduce(args, env, &eval/2)
+
+  def eval([:quote, expr], env), do: {expr, env}
+
+  def eval([:function, name, params | body], env) do
+    {env, closure_env_id} = reserve_env(env)
+    closure = {:closure, params, body, closure_env_id}
+    env = insert_env(env, closure_env_id, name, closure)
+    {closure, env}
+  end
+
+  def eval([:apply, op, args], env) do
+    {args, env} = eval(args, env)
+    {op, env} = eval(op, env)
+    eval_apply(op, args, env)
+  end
+
+  def eval_apply({:closure, params, body, closure_env_id}, args, env) do
+    caller_env_id = env_id(env)
+    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
+    callee_env = switch_env(env, closure_env_id)
+    callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
+    {callee_env, body_env_id} = reserve_env(callee_env)
+    {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
+    callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
+    {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
+    {result, switch_env(env, caller_env_id)}
+  end
+
+  def eval_apply({:native, module, functor}, args, env) do
+    {apply(module, functor, args), env}
+  end
+
+  def eval([op | args], env), do: eval([:apply, op, [:list | args]], env)
+
+  # Evaluate the given expression with a prelude prepended
 
   @doc """
   Evaluate the given expression with a prelude prepended
   """
   def eval(expr) do
     {env, prelude} = default_env()
-    # IO.inspect([[:function, :_, [] | prelude] ++ [expr]])
     eval([[:function, :_, [] | prelude] ++ [expr]], env)
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -138,9 +138,15 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def build_body_env(_, acc), do: acc
 
+  # Guards to recognize special values in the DSL
+
+  defguard is_closure(obj) when is_tuple(obj) and length(obj) == 4 and elem(obj, 0) == :closure
+
+  defguard is_native(obj) when is_tuple(obj) and length(obj) == 3 and elem(obj, 0) == :native
+
   # Evaluate the given expression in the given environment
 
-  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_function(obj) do
+  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_closure(obj) or is_native(obj) do
     {obj, env}
   end
 
@@ -156,10 +162,6 @@ defmodule Anoma.LocalDomain.Scheme do
       {{k, v}, env} end)
     {Map.new(map), env}
   end
-
-  def eval(closure = {:closure, _, _, _}, env), do: closure
-
-  def eval(native = {:native, _, _}, env), do: native
 
   def eval([:if, cond, consequent, alternate], env) do
     {cond, env} = eval(cond, env)
@@ -194,6 +196,8 @@ defmodule Anoma.LocalDomain.Scheme do
     eval(expansion, env)
   end
 
+  # Define function application syntax
+
   def eval([:apply, op, args], env) do
     {args, env} = eval(args, env)
     {op, env} = eval(op, env)
@@ -210,14 +214,19 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def eval_apply({:closure, params, body, closure_env_id}, args, env) do
     caller_env_id = env_id(env)
-    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
+    # Move to the closure/callee's environment
     callee_env = switch_env(env, closure_env_id)
+    # Bind the closure's parameters
+    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
     callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
+    # Bind mutually recursive functions in the body
     {callee_env, body_env_id} = reserve_env(callee_env)
     {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
     callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    # Evaluate the body expressions
     eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
     {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
+    # Move back to the caller's environment
     {result, switch_env(env, caller_env_id)}
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -196,23 +196,21 @@ defmodule Anoma.LocalDomain.Scheme do
       :quote ->
         {hd(args), env}
 
-      :list ->
-        {list, env} = Enum.map_reduce(args, env, fn arg, env -> eval(arg, env) end)
-        {[:list | list], env}
+      :list -> Enum.map_reduce(args, env, &eval/2)
 
       :car ->
         case eval(hd(args), env) do
-          {[:list | args], env} -> {hd(args), env}
+          {args, env} -> {hd(args), env}
           _ -> :err
         end
 
       :cdr ->
         case eval(hd(args), env) do
-          {[:list | args], env} ->
+          {args, env} ->
             if length(args) == 1 do
               {nil, env}
             else
-              {[:list | tl(args)], env}
+              {tl(args), env}
             end
 
           _ ->
@@ -223,8 +221,8 @@ defmodule Anoma.LocalDomain.Scheme do
         {car, env} = eval(hd(args), env)
 
         case eval(Enum.at(args, 1), env) do
-          {[:list | args], env} -> {[:list, car | args], env}
-          {nil, env} -> {[:list, car], env}
+          {nil, env} -> {[car], env}
+          {args, env} -> {[car | args], env}
           _ -> :err
         end
 
@@ -256,7 +254,7 @@ defmodule Anoma.LocalDomain.Scheme do
             caller_env_id = env_id(env)
             callee_env =
               Enum.reduce(
-                Enum.zip(params, tl(args)),
+                Enum.zip(params, args),
                 switch_env(env, closure_env_id),
                 fn {param, arg}, acc ->
                   put_env(acc, param, arg)
@@ -274,7 +272,7 @@ defmodule Anoma.LocalDomain.Scheme do
             {result, switch_env(env, caller_env_id)}
 
           {{:native, module, functor}, env} ->
-            {apply(module, functor, tl(args)), env}
+            {apply(module, functor, args), env}
 
           _ ->
             :op_err

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -196,12 +196,6 @@ defmodule Anoma.LocalDomain.Scheme do
 
   # Define function application syntax
 
-  def eval([:apply, op, args], env) do
-    {args, env} = eval(args, env)
-    {op, env} = eval(op, env)
-    eval_apply(op, args, env)
-  end
-
   def eval([op | args], env) do
     {args, env} = Enum.map_reduce(args, env, &eval/2)
     {op, env} = eval(op, env)

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -27,7 +27,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       is_number: {:native, :erlang, :is_number},
       car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
       cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
-      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons}
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      null: [],
     }
 
     std =

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -25,10 +25,11 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       not: {:native, :erlang, :not},
       is_integer: {:native, :erlang, :is_integer},
       is_number: {:native, :erlang, :is_number},
-      car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
-      cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
-      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      car: {:native, Kernel, :hd},
+      cdr: {:native, Kernel, :tl},
       null: [],
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null}
     }
 
     std =
@@ -39,13 +40,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
     {:ok, std}
   end
 
-  def car(list), do: hd(list)
-
-  def cdr([elt]), do: nil
-
-  def cdr(list), do: tl(list)
-
-  def cons(head, nil), do: [head]
+  def is_null(obj), do: obj == []
 
   def cons(head, tail), do: [head | tail]
 

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -24,7 +24,10 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       put: {:native, Map, :put},
       not: {:native, :erlang, :not},
       is_integer: {:native, :erlang, :is_integer},
-      is_number: {:native, :erlang, :is_number}
+      is_number: {:native, :erlang, :is_number},
+      car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
+      cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons}
     }
 
     std =
@@ -34,6 +37,16 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
     {:ok, std}
   end
+
+  def car(list), do: hd(list)
+
+  def cdr([elt]), do: nil
+
+  def cdr(list), do: tl(list)
+
+  def cons(head, nil), do: [head]
+
+  def cons(head, tail), do: [head | tail]
 
   @doc """
   Register all elixir->scheme mappings in a process.

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -4,7 +4,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme length(xs) do
     [
       :if,
-      [:==, :xs, nil],
+      [:is_null, :xs],
       0,
       [:+, 1, [:length, [:cdr, :xs]]]
     ]
@@ -22,8 +22,8 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme map(xs, f) do
     [
       :if,
-      [:==, :xs, nil],
-      nil,
+      [:is_null, :xs],
+      :null,
       [
         :cons,
         [:f, [:car, :xs]],
@@ -35,8 +35,8 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme filter(xs, f) do
     [
       :if,
-      [:==, :xs, nil],
-      nil,
+      [:is_null, :xs],
+      :null,
       [
         :if,
         [:f, [:car, :xs]],
@@ -63,7 +63,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     [
       :if,
       [:==, :n, 0],
-      nil,
+      :null,
       [
         :cons,
         [:car, :xs],

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -71,4 +71,30 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       ]
     ]
   end
+
+  defscheme apply(fun, args) do
+    [:if, [:is_null, :args],
+     [:fun],
+     [[:function, :_, [:arg0, :args],
+       [:if, [:is_null, :args],
+        [:fun, :arg0],
+        [[:function, :_, [:arg1, :args],
+          [:if, [:is_null, :args],
+           [:fun, :arg0, :arg1],
+           [[:function, :_, [:arg2, :args],
+             [:if, [:is_null, :args],
+              [:fun, :arg0, :arg1, :arg2],
+              [[:function, :_, [:arg3, :args],
+                [:if, [:is_null, :args],
+                 [:fun, :arg0, :arg1, :arg2, :arg3],
+                 [[:function, :_, [:arg4, :args],
+                   [:if, [:is_null, :args],
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4],
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4, :args]]
+                 ], [:car, :args], [:cdr, :args]]]
+              ], [:car, :args], [:cdr, :args]]]
+           ], [:car, :args], [:cdr, :args]]]
+        ], [:car, :args], [:cdr, :args]]]
+     ], [:car, :args], [:cdr, :args]]]
+  end
 end


### PR DESCRIPTION
Further experiments in order to try and more closely align the language interpreted to the one that is compiled.  There are also some additional experiments that are not strictly necessary. Specifically, the following changes have been made:
* The interpreter currently internally represents lists with the `:list` prefix (so that the internal representation matches the keyword that creates lists). This PR changes that so that lists are internally represented verbatim without a `:list` prefix because the tag/prefix seemed redundant.
* Redefined `car`, `cdr`, and `cons` as ordinary functions defined in the environment instead of as special keywords in the interpreter. This makes the core interpreter smaller and should hopefully make it easier to align with the compiler (which also does not treat `car`, `cons`, and `cdr` as special keywords).
* Combined the logic that handles self-evaluating terms like booleans and integers. This is just to try and group the self-evaluating logic and make it more concise.
* Redefined the `list` keyword for constructing lists as essentially a macro that expands to nested `cons` calls. This might make integration with the compiler easier since it does not currently support variadic functions.
* Redefined the `apply` keyword as function inside the DSL that calls a nullary function for an empty list, unary for singleton list, binary for length-2 lists, and so on. This is because it's easier to compile fixed-arity functions.
* Stopped overloading `nil` as also the empty list, and instead defined `null` which exclusively means the empty list. This makes it easier to define `list` as a macro where the inner most `cons`'s tail is the empty list.
* Use pattern matching to match each syntactical form that can be evaluated. This might be more concise/clearer than extracting parts of a form with `hd`s and `tl`s.
* Changed the way of determining whether a list is the empty list from an equality check to a newly defined `is_null` function. This is because equality in the compiler merely compares addresses, not the actual structures.