### PR TITLE
Jam+murisi/feature/elixir resource machine+macro experiments

### DIFF
--- a/lib/examples/e_action.ex
+++ b/lib/examples/e_action.ex
@@ -37,7 +37,7 @@ defmodule Examples.EAction do
     logic = Map.get(obj, "logic")
 
     {result, _env} =
-      Anoma.LocalDomain.Scheme.eval([
+      Anoma.LocalDomain.Scheme.eval([[
         :apply,
         logic,
         [
@@ -46,7 +46,7 @@ defmodule Examples.EAction do
           unit,
           consumed?
         ]
-      ])
+      ]])
 
     assert result == true
 

--- a/lib/examples/e_fixed_supply.ex
+++ b/lib/examples/e_fixed_supply.ex
@@ -67,7 +67,7 @@ defmodule Examples.EFixedSupply do
     logic = Map.get(obj, "logic")
     
     {result, _env} =
-      Anoma.LocalDomain.Scheme.eval([
+      Anoma.LocalDomain.Scheme.eval([[
         :apply,
         logic,
         [
@@ -76,7 +76,7 @@ defmodule Examples.EFixedSupply do
           unit,
           consumed?
         ]
-      ])
+      ]])
 
     assert result == true
 
@@ -98,7 +98,7 @@ defmodule Examples.EFixedSupply do
     logic = Map.get(obj, "logic")
 
     {result, _env} =
-      Anoma.LocalDomain.Scheme.eval([
+      Anoma.LocalDomain.Scheme.eval([[
         :apply,
         logic,
         [
@@ -107,7 +107,7 @@ defmodule Examples.EFixedSupply do
           unit,
           consumed?
         ]
-      ])
+      ]])
 
     assert result == true
 

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -8,7 +8,7 @@ defmodule Examples.EScheme do
   defrisc(inc(x), do: :erlang.+(x, 1))
 
   def list() do
-    [:list, 1, 2, 3]
+    {:list, 1, 2, 3}
   end
 
   def dict() do

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -20,27 +20,27 @@ defmodule Examples.EScheme do
   end
 
   def apply() do
-    {result, _env} = Scheme.eval([:apply, lambda(), [:list, 1]])
+    {result, _env} = Scheme.eval([[:apply, lambda(), [:list, 1]]])
     assert result == 2
     result
   end
 
   def native_plus() do
-    {result, _env} = Scheme.eval([:+, 1, 2])
+    {result, _env} = Scheme.eval([[:+, 1, 2]])
     assert result == 3
     result
   end
 
   def native_at() do
     expr = [:at, list(), 2]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == 3
     result
   end
 
   def map() do
     expr = [:map, list(), lambda()]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [2, 3, 4]
     result
   end
@@ -52,7 +52,7 @@ defmodule Examples.EScheme do
       [:map, [:list, 1], [:function, :_, [:x], [:+, :x, 1]]]
     ]
 
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == 3
     result
   end
@@ -79,7 +79,7 @@ defmodule Examples.EScheme do
       ]
     ]
 
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == true
     result
   end
@@ -87,43 +87,43 @@ defmodule Examples.EScheme do
   def filter() do
     filter = [:function, :_, [:x], [:==, :x, 1]]
     expr = [:filter, list(), filter]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [1]
     result
   end
 
   def nthcdr() do
     expr = [:nthcdr, list(), 2]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [3]
     result
   end
 
   def take() do
     expr = [:take, list(), 2]
-    {result, _env} = Scheme.eval(expr)
+    {result, _env} = Scheme.eval([expr])
     assert result == [1, 2]
     result
   end
 
   def get() do
-    result = Scheme.eval([:get, dict(), "a"])
+    result = Scheme.eval([[:get, dict(), "a"]])
     result
   end
 
   def put() do
-    result = Scheme.eval([:put, dict(), "b", 1])
+    result = Scheme.eval([[:put, dict(), "b", 1]])
     result
   end
 
   def car() do
-    {result, _env} = Scheme.eval([:car, list()])
+    {result, _env} = Scheme.eval([[:car, list()]])
     assert result == 1
     result
   end
 
   def cdr() do
-    {result, _env} = Scheme.eval([:cdr, list()])
+    {result, _env} = Scheme.eval([[:cdr, list()]])
     assert result == [2, 3]
     result
   end

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -75,25 +75,20 @@ defmodule Examples.EScheme do
     expr = [
       [
         :function,
-        :_,
-        [],
-        [
-          :function,
-          :odd,
-          [:n],
-          [:if, [:==, :n, 0], false, [:even, [:-, :n, 1]]]
-        ],
-        [
-          :function,
-          :even,
-          [:n],
-          [:if, [:==, :n, 0], true, [:odd, [:-, :n, 1]]]
-        ],
-        [:even, 8]
-      ]
+        :odd,
+        [:n],
+        [:if, [:==, :n, 0], false, [:even, [:-, :n, 1]]]
+      ],
+      [
+        :function,
+        :even,
+        [:n],
+        [:if, [:==, :n, 0], true, [:odd, [:-, :n, 1]]]
+      ],
+      [:even, 8]
     ]
 
-    {result, _env} = Scheme.eval([expr])
+    {result, _env} = Scheme.eval(expr)
     assert result == true
     result
   end

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -41,7 +41,7 @@ defmodule Examples.EScheme do
   def map() do
     expr = [:map, list(), lambda()]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 2, 3, 4]
+    assert result == [2, 3, 4]
     result
   end
 
@@ -88,21 +88,21 @@ defmodule Examples.EScheme do
     filter = [:function, :_, [:x], [:==, :x, 1]]
     expr = [:filter, list(), filter]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 1]
+    assert result == [1]
     result
   end
 
   def nthcdr() do
     expr = [:nthcdr, list(), 2]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 3]
+    assert result == [3]
     result
   end
 
   def take() do
     expr = [:take, list(), 2]
     {result, _env} = Scheme.eval(expr)
-    assert result == [:list, 1, 2]
+    assert result == [1, 2]
     result
   end
 
@@ -124,7 +124,7 @@ defmodule Examples.EScheme do
 
   def cdr() do
     {result, _env} = Scheme.eval([:cdr, list()])
-    assert result == [:list, 2, 3]
+    assert result == [2, 3]
     result
   end
 

--- a/lib/examples/e_scheme.ex
+++ b/lib/examples/e_scheme.ex
@@ -31,6 +31,20 @@ defmodule Examples.EScheme do
     result
   end
 
+  def and_macro() do
+    {false, _env} = Scheme.eval([{:andm, :true, :false}])
+    {true, _env} = Scheme.eval([{:andm, :true, :true, :true}])
+    {false, _env} = Scheme.eval([{:andm, :false, :true}])
+    {false, _env} = Scheme.eval([{:andm, :false, :false}])
+  end
+
+  def or_macro() do
+    {true, _env} = Scheme.eval([{:orm, :true, :false}])
+    {true, _env} = Scheme.eval([{:orm, :true, :true, :true}])
+    {true, _env} = Scheme.eval([{:orm, :false, :true}])
+    {false, _env} = Scheme.eval([{:orm, :false, :false}])
+  end
+
   def native_at() do
     expr = [:at, list(), 2]
     {result, _env} = Scheme.eval([expr])

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -72,51 +72,75 @@ defmodule Anoma.LocalDomain.Scheme do
     end), prelude_fns}
   end
 
-  def new_env(), do: {%{}, 0, 1}
-
+  def new_env(), do: {%{}, 0, 1, 0}
 
   @doc """
   Put a given binding into the environment
   """
-  def put_env({tree, index, next}, name, value) do
-    {Map.put(tree, next, {name, value, index}), next, next+1}
+  def put_env({tree, index, next, frame}, name, value) do
+    {Map.put(tree, next, {name, value, index, frame}), next, next+1, frame}
   end
 
   @doc """
   Get the value of the given identifier in the environment
   """
-  def get_env({tree, index, next}, search_name) do
+  def get_env({tree, index, next, frame}, search_name) do
     case Map.fetch(tree, index) do
-      {:ok, {^search_name, value, _parent}} -> value
-      {:ok, {_name, _value, parent}} -> get_env({tree, parent, next}, search_name)
+      {:ok, {^search_name, value, _parent, _frame}} -> value
+      {:ok, {_name, _value, parent, _frame}} -> get_env({tree, parent, next, frame}, search_name)
       :error -> raise "#{search_name} not in scope"
+    end
+  end
+
+  @doc """
+  Switch to the given stack frame
+  """
+  def switch_env_frame({tree, index, next, frame}, target) do
+    case Map.fetch(tree, index) do
+      {:ok, {_name, _value, _parent, ^target}} -> {tree, index, next, frame}
+      {:ok, {_name, _value, parent, _frame}} -> switch_env_frame({tree, parent, next, frame}, target)
+      :error -> raise "frame #{target} not in scope"
     end
   end
 
   @doc """
   Get the unique identifier for the given environment
   """
-  def env_id({_tree, index, _next}), do: index
+  def env_id({_tree, index, _next, _frame}), do: index
 
   @doc """
   Reserve a unique environment identifier to fill in later
   """
-  def reserve_env({tree, index, next}) do
-    {{tree, index, next+1}, next}
+  def reserve_env({tree, index, next, frame}) do
+    {{tree, index, next+1, frame}, next}
   end
 
   @doc """
   Insert the given binding at the given unique identifier
   """
-  def insert_env({tree, index, next}, at, name, value) do
-    {Map.put(tree, at, {name, value, index}), at, next}
+  def insert_env({tree, index, next, frame}, at, name, value) do
+    {Map.put(tree, at, {name, value, index, frame}), at, next, frame}
   end
 
   @doc """
   Switch to the given environment
   """
-  def switch_env({tree, _index, next}, target) do
-    {tree, target, next}
+  def switch_env({tree, _index, next, frame}, target) do
+    {tree, target, next, frame}
+  end
+
+  @doc """
+  Push new stack frame onto the environment
+  """
+  def push_env_frame({tree, index, next, frame}) do
+    {tree, index, next, frame+1}
+  end
+
+  @doc """
+  Pop stack frame from the environment
+  """
+  def pop_env_frame({tree, index, next, frame}) do
+    {tree, index, next, frame-1}
   end
 
   @doc """
@@ -185,7 +209,14 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def eval(expr = [:expand | _], env) do
-    eval(elem(expand_macros(expr, env), 0), env)
+    # Save the environment just before macro expansion
+    expansion_env_id = env_id(env)
+    # Macro expansion cannot access locals - switch to global environment
+    macro_env = switch_env_frame(env, 0)
+    # Expand the macro in the global environment
+    {expansion, macro_env} = expand_macros(expr, macro_env)
+    # Finally evaluate the expanded macro in original environment
+    eval(expansion, switch_env(macro_env, expansion_env_id))
   end
 
   # Define evaluate by reducing to simpler expressions
@@ -217,6 +248,7 @@ defmodule Anoma.LocalDomain.Scheme do
     caller_env_id = env_id(env)
     # Move to the closure/callee's environment
     callee_env = switch_env(env, closure_env_id)
+    callee_env = push_env_frame(callee_env)
     # Bind the closure's parameters
     put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
     callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
@@ -226,6 +258,7 @@ defmodule Anoma.LocalDomain.Scheme do
     eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
     {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
     # Move back to the caller's environment
+    env = pop_env_frame(env)
     {result, switch_env(env, caller_env_id)}
   end
 
@@ -234,11 +267,6 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   # Recursively expand macros
-
-  def expand_macros({:closure, params, body, closure_env_id}, env) do
-    {body, env} = expand_macros(body, env)
-    {{:closure, params, body, closure_env_id}, env}
-  end
 
   def expand_macros(expr = [:expand, reference | _], env) do
     # Evaluate the reference expression - this should result in a function

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -86,11 +86,10 @@ defmodule Anoma.LocalDomain.Scheme do
   Get the value of the given identifier in the environment
   """
   def get_env({tree, index, next}, search_name) do
-    {name, value, parent} = Map.fetch!(tree, index)
-    if name == search_name do
-      value
-    else
-      get_env({tree, parent, next}, search_name)
+    case Map.fetch(tree, index) do
+      {:ok, {^search_name, value, _parent}} -> value
+      {:ok, {_name, _value, parent}} -> get_env({tree, parent, next}, search_name)
+      :error -> raise "#{search_name} not in scope"
     end
   end
 
@@ -146,9 +145,9 @@ defmodule Anoma.LocalDomain.Scheme do
 
   # Guards to recognize special values in the DSL
 
-  defguard is_closure(obj) when is_tuple(obj) and length(obj) == 4 and elem(obj, 0) == :closure
+  defguard is_closure(obj) when is_tuple(obj) and tuple_size(obj) == 4 and elem(obj, 0) == :closure
 
-  defguard is_native(obj) when is_tuple(obj) and length(obj) == 3 and elem(obj, 0) == :native
+  defguard is_native(obj) when is_tuple(obj) and tuple_size(obj) == 3 and elem(obj, 0) == :native
 
   # Evaluate the given expression in the given environment
 
@@ -183,6 +182,10 @@ defmodule Anoma.LocalDomain.Scheme do
     closure = {:closure, params, body, closure_env_id}
     env = insert_env(env, closure_env_id, name, closure)
     {closure, env}
+  end
+
+  def eval(expr = [:expand | _], env) do
+    eval(elem(expand_macros(expr, env), 0), env)
   end
 
   # Define evaluate by reducing to simpler expressions
@@ -238,12 +241,8 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def expand_macros(expr = [:expand, reference | _], env) do
-    # Expand the macros in the reference expression
-    {reference, env} = expand_macros(reference, env)
     # Evaluate the reference expression - this should result in a function
     {reference, env} = eval(reference, env)
-    # Expand the macros used in the value of the reference expression
-    {reference, env} = expand_macros(reference, env)
     # Apply the reference expression to representation of this expression
     {expansion, env} = eval_apply(reference, [expr], env)
     # Finally, attempt to expand the output of the macro

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -137,33 +137,15 @@ defmodule Anoma.LocalDomain.Scheme do
   end
 
   def build_body_env(_, acc), do: acc
-  
-  def eval(num, env) when is_number(num) do
-    {num, env}
-  end
 
-  def eval(true, env) do
-    {true, env}
-  end
+  # Evaluate the given expression in the given environment
 
-  def eval(false, env) do
-    {false, env}
-  end
-
-  def eval(nil, env) do
-    {nil, env}
-  end
-
-  def eval(str, env) when is_binary(str) do
-    {str, env}
+  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_function(obj) do
+    {obj, env}
   end
 
   def eval(var, env) when is_atom(var) do
     {get_env(env, var), env}
-  end
-
-  def eval(func, env) when is_function(func) do
-    {func, env}
   end
 
   def eval(map, env) when is_map(map) do

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -170,16 +170,6 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
-  def eval([:and, expr1, expr2], env) do
-    eval([:if, expr1, expr2, false], env)
-  end
-
-  def eval([:or, expr1, expr2], env) do
-    eval([:if, expr1, true, expr2], env)
-  end
-
-  def eval([:list | args], env), do: Enum.map_reduce(args, env, &eval/2)
-
   def eval([:quote, expr], env), do: {expr, env}
 
   def eval([:function, name, params | body], env) do
@@ -189,11 +179,34 @@ defmodule Anoma.LocalDomain.Scheme do
     {closure, env}
   end
 
+  # Define evaluate by reducing to simpler expressions
+
+  def eval([:and, expr1, expr2], env) do
+    eval([:if, expr1, expr2, false], env)
+  end
+
+  def eval([:or, expr1, expr2], env) do
+    eval([:if, expr1, true, expr2], env)
+  end
+
+  def eval([:list | args], env) do
+    expansion = Enum.reduce(Enum.reverse(args), :null, fn elt, acc -> [:cons, elt, acc] end)
+    eval(expansion, env)
+  end
+
   def eval([:apply, op, args], env) do
     {args, env} = eval(args, env)
     {op, env} = eval(op, env)
     eval_apply(op, args, env)
   end
+
+  def eval([op | args], env) do
+    {args, env} = Enum.map_reduce(args, env, &eval/2)
+    {op, env} = eval(op, env)
+    eval_apply(op, args, env)
+  end
+
+  # Apply the given arguments to the given function
 
   def eval_apply({:closure, params, body, closure_env_id}, args, env) do
     caller_env_id = env_id(env)
@@ -211,8 +224,6 @@ defmodule Anoma.LocalDomain.Scheme do
   def eval_apply({:native, module, functor}, args, env) do
     {apply(module, functor, args), env}
   end
-
-  def eval([op | args], env), do: eval([:apply, op, [:list | args]], env)
 
   # Evaluate the given expression with a prelude prepended
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -198,34 +198,6 @@ defmodule Anoma.LocalDomain.Scheme do
 
       :list -> Enum.map_reduce(args, env, &eval/2)
 
-      :car ->
-        case eval(hd(args), env) do
-          {args, env} -> {hd(args), env}
-          _ -> :err
-        end
-
-      :cdr ->
-        case eval(hd(args), env) do
-          {args, env} ->
-            if length(args) == 1 do
-              {nil, env}
-            else
-              {tl(args), env}
-            end
-
-          _ ->
-            :cdr_err
-        end
-
-      :cons ->
-        {car, env} = eval(hd(args), env)
-
-        case eval(Enum.at(args, 1), env) do
-          {nil, env} -> {[car], env}
-          {args, env} -> {[car | args], env}
-          _ -> :err
-        end
-
       :and ->
         case eval(hd(args), env) do
           {true, env} -> eval(Enum.at(args, 1), env)

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -172,8 +172,6 @@ defmodule Anoma.LocalDomain.Scheme do
     end
   end
 
-  def eval([:quote, expr], env), do: {expr, env}
-
   def eval([:function, name, params | body], env) do
     {env, closure_env_id} = reserve_env(env)
     closure = {:closure, params, body, closure_env_id}

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -132,11 +132,17 @@ defmodule Anoma.LocalDomain.Scheme do
   @doc """
   Add functions to the environment
   """
-  def build_body_env([:function, name, params | body], {env, body_env_id}) do
+  def bind_function([:function, name, params | body], {env, body_env_id}) do
     {put_env(env, name, {:closure, params, body, body_env_id}), body_env_id}
   end
 
-  def build_body_env(_, acc), do: acc
+  def bind_function(_, acc), do: acc
+
+  def build_body_env(body, callee_env) do
+    {callee_env, body_env_id} = reserve_env(callee_env)
+    {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &bind_function/2)
+    insert_env(callee_env, body_env_id, nil, nil)
+  end
 
   # Guards to recognize special values in the DSL
 
@@ -212,9 +218,7 @@ defmodule Anoma.LocalDomain.Scheme do
     put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
     callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
     # Bind mutually recursive functions in the body
-    {callee_env, body_env_id} = reserve_env(callee_env)
-    {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
-    callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    callee_env = build_body_env(body, callee_env)
     # Evaluate the body expressions
     eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
     {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
@@ -226,14 +230,44 @@ defmodule Anoma.LocalDomain.Scheme do
     {apply(module, functor, args), env}
   end
 
+  # Recursively expand macros
+
+  def expand_macros(expr = [:expand, reference | _], env) do
+    {reference, env} = eval(reference, env)
+    {expansion, env} = eval_apply(reference, [expr], env)
+    expand_macros(expansion, env)
+  end
+
+  def expand_macros(expr, env) when is_list(expr) do
+    Enum.map_reduce(expr, env, &expand_macros/2)
+  end
+
+  def expand_macros(expr, env), do: {expr, env}
+
+  # Recursively expand tuples to lists
+
+  def expand_tuples(expr) when is_tuple(expr) do
+    expand_tuples([:expand | Tuple.to_list(expr)])
+  end
+
+  def expand_tuples(expr) when is_list(expr) do
+    Enum.map(expr, &expand_tuples/1)
+  end
+
+  def expand_tuples(expr), do: expr
+
   # Evaluate the given expression with a prelude prepended
 
   @doc """
   Evaluate the given expression with a prelude prepended
   """
-  def eval(expr) do
+  def eval(exprs) do
     {env, prelude} = default_env()
-    eval([[:function, :_, [] | prelude] ++ [expr]], env)
+    exprs = prelude ++ exprs
+    exprs = Enum.map(exprs, &expand_tuples/1)
+    funcs = build_body_env(exprs, env)
+    {exprs, _} = Enum.map_reduce(exprs, funcs, &expand_macros/2)
+    eval([[:function, :_, [] | exprs]], env)
   end
 
   @doc """

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -157,92 +157,70 @@ defmodule Anoma.LocalDomain.Scheme do
     {Map.new(map), env}
   end
 
-  def eval({:closure, params, body, closure_env_id}, env) do
-    {{:closure, params, body, closure_env_id}, env}
-  end
+  def eval(closure = {:closure, _, _, _}, env), do: closure
 
-  def eval({:native, module, functor}, env) do
-    {{:native, module, functor}, env}
-  end
+  def eval(native = {:native, _, _}, env), do: native
 
-  def eval([op | args], env) do
-    case op do
-      :if ->
-        {cond, env} = eval(hd(args), env)
-        if cond do
-          eval(Enum.at(args, 1), env)
-        else
-          eval(Enum.at(args, 2), env)
-        end
-
-      :quote ->
-        {hd(args), env}
-
-      :list -> Enum.map_reduce(args, env, &eval/2)
-
-      :and ->
-        case eval(hd(args), env) do
-          {true, env} -> eval(Enum.at(args, 1), env)
-          {false, env} -> {false, env}
-        end
-
-      :or ->
-        case eval(hd(args), env) do
-          {env, true} -> {true, env}
-          {false, env} -> eval(Enum.at(args, 1), env)
-        end
-
-      :function ->
-        {env, closure_env_id} = reserve_env(env)
-        closure = {:closure, Enum.at(args, 1), tl(tl(args)), closure_env_id}
-        env = insert_env(env, closure_env_id, hd(args), closure)
-        {closure, env}
-        
-        :apply ->
-        [op, args] = args
-
-        {args, env} = eval(args, env)
-
-        case eval(op, env) do
-          {{:closure, params, body, closure_env_id}, env} ->
-            caller_env_id = env_id(env)
-            callee_env =
-              Enum.reduce(
-                Enum.zip(params, args),
-                switch_env(env, closure_env_id),
-                fn {param, arg}, acc ->
-                  put_env(acc, param, arg)
-                end
-              )
-
-            {callee_env, body_env_id} = reserve_env(callee_env)
-
-            {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
-
-            callee_env = insert_env(callee_env, body_env_id, nil, nil)
-
-            {result, env} = Enum.reduce(body, {nil, callee_env}, fn expr, {_result, call_env} -> eval(expr, call_env) end)
-
-            {result, switch_env(env, caller_env_id)}
-
-          {{:native, module, functor}, env} ->
-            {apply(module, functor, args), env}
-
-          _ ->
-            :op_err
-        end
-
-      _ ->
-        eval([:apply, op, [:list | args]], env)
+  def eval([:if, cond, consequent, alternate], env) do
+    {cond, env} = eval(cond, env)
+    if cond do
+      eval(consequent, env)
+    else
+      eval(alternate, env)
     end
   end
+
+  def eval([:and, expr1, expr2], env) do
+    eval([:if, expr1, expr2, false], env)
+  end
+
+  def eval([:or, expr1, expr2], env) do
+    eval([:if, expr1, true, expr2], env)
+  end
+
+  def eval([:list | args], env), do: Enum.map_reduce(args, env, &eval/2)
+
+  def eval([:quote, expr], env), do: {expr, env}
+
+  def eval([:function, name, params | body], env) do
+    {env, closure_env_id} = reserve_env(env)
+    closure = {:closure, params, body, closure_env_id}
+    env = insert_env(env, closure_env_id, name, closure)
+    {closure, env}
+  end
+
+  def eval([:apply, op, args], env) do
+    {args, env} = eval(args, env)
+    {op, env} = eval(op, env)
+    eval_apply(op, args, env)
+  end
+
+  def eval_apply({:closure, params, body, closure_env_id}, args, env) do
+    caller_env_id = env_id(env)
+    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
+    callee_env = switch_env(env, closure_env_id)
+    callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
+    {callee_env, body_env_id} = reserve_env(callee_env)
+    {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
+    callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
+    {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
+    {result, switch_env(env, caller_env_id)}
+  end
+
+  def eval_apply({:native, module, functor}, args, env) do
+    {apply(module, functor, args), env}
+  end
+
+  def eval([op | args], env), do: eval([:apply, op, [:list | args]], env)
+
+  # Evaluate the given expression with a prelude prepended
 
   @doc """
   Evaluate the given expression with a prelude prepended
   """
   def eval(expr) do
     {env, prelude} = default_env()
-    # IO.inspect([[:function, :_, [] | prelude] ++ [expr]])
     eval([[:function, :_, [] | prelude] ++ [expr]], env)
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -138,9 +138,15 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def build_body_env(_, acc), do: acc
 
+  # Guards to recognize special values in the DSL
+
+  defguard is_closure(obj) when is_tuple(obj) and length(obj) == 4 and elem(obj, 0) == :closure
+
+  defguard is_native(obj) when is_tuple(obj) and length(obj) == 3 and elem(obj, 0) == :native
+
   # Evaluate the given expression in the given environment
 
-  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_function(obj) do
+  def eval(obj, env) when is_number(obj) or is_boolean(obj) or is_binary(obj) or is_nil(obj) or is_closure(obj) or is_native(obj) do
     {obj, env}
   end
 
@@ -156,10 +162,6 @@ defmodule Anoma.LocalDomain.Scheme do
       {{k, v}, env} end)
     {Map.new(map), env}
   end
-
-  def eval(closure = {:closure, _, _, _}, env), do: closure
-
-  def eval(native = {:native, _, _}, env), do: native
 
   def eval([:if, cond, consequent, alternate], env) do
     {cond, env} = eval(cond, env)
@@ -194,6 +196,8 @@ defmodule Anoma.LocalDomain.Scheme do
     eval(expansion, env)
   end
 
+  # Define function application syntax
+
   def eval([:apply, op, args], env) do
     {args, env} = eval(args, env)
     {op, env} = eval(op, env)
@@ -210,14 +214,19 @@ defmodule Anoma.LocalDomain.Scheme do
 
   def eval_apply({:closure, params, body, closure_env_id}, args, env) do
     caller_env_id = env_id(env)
-    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
+    # Move to the closure/callee's environment
     callee_env = switch_env(env, closure_env_id)
+    # Bind the closure's parameters
+    put_env = fn {param, arg}, acc -> put_env(acc, param, arg) end
     callee_env = Enum.reduce(Enum.zip(params, args), callee_env, put_env)
+    # Bind mutually recursive functions in the body
     {callee_env, body_env_id} = reserve_env(callee_env)
     {callee_env, body_env_id} = Enum.reduce(body, {callee_env, body_env_id}, &build_body_env/2)
     callee_env = insert_env(callee_env, body_env_id, nil, nil)
+    # Evaluate the body expressions
     eval = fn expr, {_result, call_env} -> eval(expr, call_env) end
     {result, env} = Enum.reduce(body, {nil, callee_env}, eval)
+    # Move back to the caller's environment
     {result, switch_env(env, caller_env_id)}
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -196,23 +196,21 @@ defmodule Anoma.LocalDomain.Scheme do
       :quote ->
         {hd(args), env}
 
-      :list ->
-        {list, env} = Enum.map_reduce(args, env, fn arg, env -> eval(arg, env) end)
-        {[:list | list], env}
+      :list -> Enum.map_reduce(args, env, &eval/2)
 
       :car ->
         case eval(hd(args), env) do
-          {[:list | args], env} -> {hd(args), env}
+          {args, env} -> {hd(args), env}
           _ -> :err
         end
 
       :cdr ->
         case eval(hd(args), env) do
-          {[:list | args], env} ->
+          {args, env} ->
             if length(args) == 1 do
               {nil, env}
             else
-              {[:list | tl(args)], env}
+              {tl(args), env}
             end
 
           _ ->
@@ -223,8 +221,8 @@ defmodule Anoma.LocalDomain.Scheme do
         {car, env} = eval(hd(args), env)
 
         case eval(Enum.at(args, 1), env) do
-          {[:list | args], env} -> {[:list, car | args], env}
-          {nil, env} -> {[:list, car], env}
+          {nil, env} -> {[car], env}
+          {args, env} -> {[car | args], env}
           _ -> :err
         end
 
@@ -256,7 +254,7 @@ defmodule Anoma.LocalDomain.Scheme do
             caller_env_id = env_id(env)
             callee_env =
               Enum.reduce(
-                Enum.zip(params, tl(args)),
+                Enum.zip(params, args),
                 switch_env(env, closure_env_id),
                 fn {param, arg}, acc ->
                   put_env(acc, param, arg)
@@ -274,7 +272,7 @@ defmodule Anoma.LocalDomain.Scheme do
             {result, switch_env(env, caller_env_id)}
 
           {{:native, module, functor}, env} ->
-            {apply(module, functor, tl(args)), env}
+            {apply(module, functor, args), env}
 
           _ ->
             :op_err

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -232,9 +232,21 @@ defmodule Anoma.LocalDomain.Scheme do
 
   # Recursively expand macros
 
+  def expand_macros({:closure, params, body, closure_env_id}, env) do
+    {body, env} = expand_macros(body, env)
+    {{:closure, params, body, closure_env_id}, env}
+  end
+
   def expand_macros(expr = [:expand, reference | _], env) do
+    # Expand the macros in the reference expression
+    {reference, env} = expand_macros(reference, env)
+    # Evaluate the reference expression - this should result in a function
     {reference, env} = eval(reference, env)
+    # Expand the macros used in the value of the reference expression
+    {reference, env} = expand_macros(reference, env)
+    # Apply the reference expression to representation of this expression
     {expansion, env} = eval_apply(reference, [expr], env)
+    # Finally, attempt to expand the output of the macro
     expand_macros(expansion, env)
   end
 
@@ -263,10 +275,17 @@ defmodule Anoma.LocalDomain.Scheme do
   """
   def eval(exprs) do
     {env, prelude} = default_env()
+    # Add the top-level functions to the prelude
     exprs = prelude ++ exprs
+    # Remove the syntactic sugar for macros
     exprs = Enum.map(exprs, &expand_tuples/1)
-    funcs = build_body_env(exprs, env)
-    {exprs, _} = Enum.map_reduce(exprs, funcs, &expand_macros/2)
+    # Create an environment where all macros are bound
+    macro_env = build_body_env(exprs, env)
+    # Expand all macro calls, macro environment not needed afterwards
+    {exprs, _} = Enum.map_reduce(exprs, macro_env, &expand_macros/2)
+    # Create new environment where all bindings have been expanded
+    env = build_body_env(exprs, env)
+    # Finally evaluate the expanded expressions in the context of an expanded environment
     eval([[:function, :_, [] | exprs]], env)
   end
 

--- a/lib/local_domain/scheme/scheme.ex
+++ b/lib/local_domain/scheme/scheme.ex
@@ -196,12 +196,6 @@ defmodule Anoma.LocalDomain.Scheme do
 
   # Define function application syntax
 
-  def eval([:apply, op, args], env) do
-    {args, env} = eval(args, env)
-    {op, env} = eval(op, env)
-    eval_apply(op, args, env)
-  end
-
   def eval([op | args], env) do
     {args, env} = Enum.map_reduce(args, env, &eval/2)
     {op, env} = eval(op, env)

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -31,7 +31,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
       is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null},
       atom_to_string: {:native, Macro, :to_string},
-      string_to_atom: {:native, Code, :string_to_quoted!}
+      string_to_atom: {:native, Code, :string_to_quoted!},
+      is_pair: {:native, Anoma.LocalDomain.SchemeRegistry, :is_pair}
     }
 
     std =
@@ -45,6 +46,10 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
   def is_null(obj), do: obj == []
 
   def cons(head, tail), do: [head | tail]
+
+  def is_pair([_ | _]), do: true
+
+  def is_pair(_), do: false
 
   @doc """
   Register all elixir->scheme mappings in a process.

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -29,7 +29,9 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       cdr: {:native, Kernel, :tl},
       null: [],
       cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
-      is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null}
+      is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null},
+      atom_to_string: {:native, Macro, :to_string},
+      string_to_atom: {:native, Code, :string_to_quoted!}
     }
 
     std =

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -27,7 +27,8 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       is_number: {:native, :erlang, :is_number},
       car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
       cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
-      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons}
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      null: [],
     }
 
     std =

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -25,10 +25,11 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       not: {:native, :erlang, :not},
       is_integer: {:native, :erlang, :is_integer},
       is_number: {:native, :erlang, :is_number},
-      car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
-      cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
-      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      car: {:native, Kernel, :hd},
+      cdr: {:native, Kernel, :tl},
       null: [],
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons},
+      is_null: {:native, Anoma.LocalDomain.SchemeRegistry, :is_null}
     }
 
     std =
@@ -39,13 +40,7 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
     {:ok, std}
   end
 
-  def car(list), do: hd(list)
-
-  def cdr([elt]), do: nil
-
-  def cdr(list), do: tl(list)
-
-  def cons(head, nil), do: [head]
+  def is_null(obj), do: obj == []
 
   def cons(head, tail), do: [head | tail]
 

--- a/lib/local_domain/scheme/scheme_registry.ex
+++ b/lib/local_domain/scheme/scheme_registry.ex
@@ -24,7 +24,10 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
       put: {:native, Map, :put},
       not: {:native, :erlang, :not},
       is_integer: {:native, :erlang, :is_integer},
-      is_number: {:native, :erlang, :is_number}
+      is_number: {:native, :erlang, :is_number},
+      car: {:native, Anoma.LocalDomain.SchemeRegistry, :car},
+      cdr: {:native, Anoma.LocalDomain.SchemeRegistry, :cdr},
+      cons: {:native, Anoma.LocalDomain.SchemeRegistry, :cons}
     }
 
     std =
@@ -34,6 +37,16 @@ defmodule Anoma.LocalDomain.SchemeRegistry do
 
     {:ok, std}
   end
+
+  def car(list), do: hd(list)
+
+  def cdr([elt]), do: nil
+
+  def cdr(list), do: tl(list)
+
+  def cons(head, nil), do: [head]
+
+  def cons(head, tail), do: [head | tail]
 
   @doc """
   Register all elixir->scheme mappings in a process.

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -4,7 +4,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme length(xs) do
     [
       :if,
-      [:==, :xs, nil],
+      [:is_null, :xs],
       0,
       [:+, 1, [:length, [:cdr, :xs]]]
     ]
@@ -22,8 +22,8 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme map(xs, f) do
     [
       :if,
-      [:==, :xs, nil],
-      nil,
+      [:is_null, :xs],
+      :null,
       [
         :cons,
         [:f, [:car, :xs]],
@@ -35,8 +35,8 @@ defmodule Anoma.LocalDomain.Scheme.Std do
   defscheme filter(xs, f) do
     [
       :if,
-      [:==, :xs, nil],
-      nil,
+      [:is_null, :xs],
+      :null,
       [
         :if,
         [:f, [:car, :xs]],
@@ -63,7 +63,7 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     [
       :if,
       [:==, :n, 0],
-      nil,
+      :null,
       [
         :cons,
         [:car, :xs],

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -84,15 +84,46 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     [:caddr, [:cdr, :sexpr]]
   end
 
-  defscheme let(sexpr) do
-    [:cons,
-     [:cons,
-      [:string_to_atom, ":function"],
-      [:cons, [:string_to_atom, ":let_aux"],
+  defscheme cdddr(sexpr) do
+    [:cddr, [:cdr, :sexpr]]
+  end
+
+  defscheme cddr(sexpr) do
+    [:cdr, [:cdr, :sexpr]]
+  end
+
+  defscheme quote_aux(sexpr) do
+    [:if, [:is_null, :sexpr],
+     [:string_to_atom, ":null"],
+     [:if, [:is_pair, :sexpr],
+      [:if,
+       [:if, [:==, [:car, :sexpr], [:string_to_atom, ":unquote"]],
+        [:is_null, [:cddr, :sexpr]],
+        false],
+       [:cadr, :sexpr],
        [:cons,
-        [:map, [:caddr, :sexpr], :car],
-        [:cons, [:cadddr, :sexpr], :null]]]],
-     [:map, [:caddr, :sexpr], :cadr]]
+        [:string_to_atom, ":cons"],
+        [:cons,
+         [:quote_aux, [:car, :sexpr]],
+         [:cons, [:quote_aux, [:cdr, :sexpr]], :null]]]],
+      [:cons,
+       [:string_to_atom, ":string_to_atom"],
+       [:cons, [:atom_to_string, :sexpr], :null]]]]
+  end
+
+  defscheme quote(sexpr) do
+    [:quote_aux, [:caddr, :sexpr]]
+  end
+
+  defscheme let(sexpr) do
+    {:quote,
+     [[:function, :let_aux,
+       # binding names
+       [:unquote, [:map, [:caddr, :sexpr], :car]],
+       # body
+       :unquote, [:cdddr, :sexpr]],
+      # binding values
+      :unquote, [:map, [:caddr, :sexpr], :cadr]]}
   end
 
   defscheme apply(fun, args) do

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -92,27 +92,25 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     [:cdr, [:cdr, :sexpr]]
   end
 
-  defscheme quote_aux(sexpr) do
-    [:if, [:is_null, :sexpr],
-     [:string_to_atom, ":null"],
-     [:if, [:is_pair, :sexpr],
-      [:if,
-       [:if, [:==, [:car, :sexpr], [:string_to_atom, ":unquote"]],
-        [:is_null, [:cddr, :sexpr]],
-        false],
-       [:cadr, :sexpr],
-       [:cons,
-        [:string_to_atom, ":cons"],
-        [:cons,
-         [:quote_aux, [:car, :sexpr]],
-         [:cons, [:quote_aux, [:cdr, :sexpr]], :null]]]],
-      [:cons,
-       [:string_to_atom, ":string_to_atom"],
-       [:cons, [:atom_to_string, :sexpr], :null]]]]
-  end
-
   defscheme quote(sexpr) do
-    [:quote_aux, [:caddr, :sexpr]]
+    [[:function, :quote_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":null"],
+       [:if, [:is_pair, :sexpr],
+        [:if,
+         [:if, [:==, [:car, :sexpr], [:string_to_atom, ":unquote"]],
+          [:is_null, [:cddr, :sexpr]],
+          false],
+         [:cadr, :sexpr],
+         [:cons,
+          [:string_to_atom, ":cons"],
+          [:cons,
+           [:quote_aux, [:car, :sexpr]],
+           [:cons, [:quote_aux, [:cdr, :sexpr]], :null]]]],
+        [:cons,
+         [:string_to_atom, ":string_to_atom"],
+         [:cons, [:atom_to_string, :sexpr], :null]]]]
+    ], [:caddr, :sexpr]]
   end
 
   defscheme let(sexpr) do
@@ -124,6 +122,26 @@ defmodule Anoma.LocalDomain.Scheme.Std do
        :unquote, [:cdddr, :sexpr]],
       # binding values
       :unquote, [:map, [:caddr, :sexpr], :cadr]]}
+  end
+
+  defscheme andm(sexpr) do
+    [[:function, :andm_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":true"],
+       {:quote,
+        {:let, [[:and_temp, [:unquote, [:car, :sexpr]]]],
+         [:if, :and_temp, [:unquote, [:andm_aux, [:cdr, :sexpr]]], :and_temp]}}]
+    ], [:cddr, :sexpr]]
+  end
+
+  defscheme orm(sexpr) do
+    [[:function, :orm_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":false"],
+       {:quote,
+        {:let, [[:or_temp, [:unquote, [:car, :sexpr]]]],
+         [:if, :or_temp, :or_temp, [:unquote, [:orm_aux, [:cdr, :sexpr]]]]}}]
+    ], [:cddr, :sexpr]]
   end
 
   defscheme apply(fun, args) do

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -72,29 +72,47 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     ]
   end
 
+  defscheme cadr(sexpr) do
+    [:car, [:cdr, :sexpr]]
+  end
+
+  defscheme caddr(sexpr) do
+    [:cadr, [:cdr, :sexpr]]
+  end
+
+  defscheme cadddr(sexpr) do
+    [:caddr, [:cdr, :sexpr]]
+  end
+
+  defscheme let(sexpr) do
+    [:cons,
+     [:cons,
+      [:string_to_atom, ":function"],
+      [:cons, [:string_to_atom, ":let_aux"],
+       [:cons,
+        [:map, [:caddr, :sexpr], :car],
+        [:cons, [:cadddr, :sexpr], :null]]]],
+     [:map, [:caddr, :sexpr], :cadr]]
+  end
+
   defscheme apply(fun, args) do
     [:if, [:is_null, :args],
      [:fun],
-     [[:function, :_, [:arg0, :args],
+     {:let, [[:arg0, [:car, :args]], [:args, [:cdr, :args]]],
        [:if, [:is_null, :args],
         [:fun, :arg0],
-        [[:function, :_, [:arg1, :args],
+        {:let, [[:arg1, [:car, :args]], [:args, [:cdr, :args]]],
           [:if, [:is_null, :args],
            [:fun, :arg0, :arg1],
-           [[:function, :_, [:arg2, :args],
+           {:let, [[:arg2, [:car, :args]], [:args, [:cdr, :args]]],
              [:if, [:is_null, :args],
               [:fun, :arg0, :arg1, :arg2],
-              [[:function, :_, [:arg3, :args],
+              {:let, [[:arg3, [:car, :args]], [:args, [:cdr, :args]]],
                 [:if, [:is_null, :args],
                  [:fun, :arg0, :arg1, :arg2, :arg3],
-                 [[:function, :_, [:arg4, :args],
+                 {:let, [[:arg4, [:car, :args]], [:args, [:cdr, :args]]],
                    [:if, [:is_null, :args],
                     [:fun, :arg0, :arg1, :arg2, :arg3, :arg4],
-                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4, :args]]
-                 ], [:car, :args], [:cdr, :args]]]
-              ], [:car, :args], [:cdr, :args]]]
-           ], [:car, :args], [:cdr, :args]]]
-        ], [:car, :args], [:cdr, :args]]]
-     ], [:car, :args], [:cdr, :args]]]
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4, :args]]}]}]}]}]}]
   end
 end

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -144,6 +144,15 @@ defmodule Anoma.LocalDomain.Scheme.Std do
     ], [:cddr, :sexpr]]
   end
 
+  defscheme list(sexpr) do
+    [[:function, :list_aux, [:sexpr],
+      [:if, [:is_null, :sexpr],
+       [:string_to_atom, ":null"],
+       {:quote,
+        [:cons, [:unquote, [:car, :sexpr]], [:unquote, [:list_aux, [:cdr, :sexpr]]]]}]
+    ], [:cddr, :sexpr]]
+  end
+
   defscheme apply(fun, args) do
     [:if, [:is_null, :args],
      [:fun],

--- a/lib/local_domain/scheme/std.ex
+++ b/lib/local_domain/scheme/std.ex
@@ -71,4 +71,30 @@ defmodule Anoma.LocalDomain.Scheme.Std do
       ]
     ]
   end
+
+  defscheme apply(fun, args) do
+    [:if, [:is_null, :args],
+     [:fun],
+     [[:function, :_, [:arg0, :args],
+       [:if, [:is_null, :args],
+        [:fun, :arg0],
+        [[:function, :_, [:arg1, :args],
+          [:if, [:is_null, :args],
+           [:fun, :arg0, :arg1],
+           [[:function, :_, [:arg2, :args],
+             [:if, [:is_null, :args],
+              [:fun, :arg0, :arg1, :arg2],
+              [[:function, :_, [:arg3, :args],
+                [:if, [:is_null, :args],
+                 [:fun, :arg0, :arg1, :arg2, :arg3],
+                 [[:function, :_, [:arg4, :args],
+                   [:if, [:is_null, :args],
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4],
+                    [:fun, :arg0, :arg1, :arg2, :arg3, :arg4, :args]]
+                 ], [:car, :args], [:cdr, :args]]]
+              ], [:car, :args], [:cdr, :args]]]
+           ], [:car, :args], [:cdr, :args]]]
+        ], [:car, :args], [:cdr, :args]]]
+     ], [:car, :args], [:cdr, :args]]]
+  end
 end

--- a/test/scheme_test.exs
+++ b/test/scheme_test.exs
@@ -14,6 +14,8 @@ defmodule SchemeTest do
     Examples.EScheme.lambda()
     Examples.EScheme.apply()
     Examples.EScheme.native_plus()
+    Examples.EScheme.and_macro()
+    Examples.EScheme.or_macro()
     Examples.EScheme.native_at()
     Examples.EScheme.map()
     Examples.EScheme.apply_map()


### PR DESCRIPTION
Implemented macro expansion, then used macros to implement let-bindings, short circuit logical operators, and variadic list construction. Made some examples using these macros. The purpose of this PR is to minimize the amount of keywords implemented inside the interpreter itself and instead have keywords implemented as macros. This allows us to define keywords only once inside the DSL and have them supported by both the interpreter and the compiler. The second purpose of this PR is to facilitate exploring what DSL features can be pushed into compile-time expansions and hence don't require additional runtime support to achieve.